### PR TITLE
Feature/remove required geo headers

### DIFF
--- a/src/objects/api/views.py
+++ b/src/objects/api/views.py
@@ -17,7 +17,7 @@ from .serializers import (
 )
 
 
-class ObjectViewSet(SearchMixin, GeoMixin, viewsets.ModelViewSet):
+class ObjectViewSet(SearchMixin, viewsets.ModelViewSet):
     queryset = Object.objects.order_by("-pk")
     serializer_class = ObjectSerializer
     filterset_class = ObjectFilterSet

--- a/src/objects/conf/api.py
+++ b/src/objects/conf/api.py
@@ -18,9 +18,7 @@ SWAGGER_SETTINGS.update(
     {
         "DEFAULT_INFO": "objects.api.schema.info",
         "SECURITY_DEFINITIONS": None,
-        "DEFAULT_FIELD_INSPECTORS": (
-            "vng_api_common.inspectors.geojson.GeometryFieldInspector",
-        )
+        "DEFAULT_FIELD_INSPECTORS": ("objects.utils.inspectors.GeometryFieldInspector",)
         + BASE_SWAGGER_SETTINGS["DEFAULT_FIELD_INSPECTORS"],
     }
 )

--- a/src/objects/tests/test_filters.py
+++ b/src/objects/tests/test_filters.py
@@ -5,8 +5,6 @@ from rest_framework.test import APITestCase
 
 from objects.core.tests.factores import ObjectFactory
 
-from .utils import GEO_READ_KWARGS
-
 OBJECT_TYPE = "https://example.com/objecttypes/v1/types/a6c109"
 
 
@@ -17,7 +15,7 @@ class FilterTests(APITestCase):
         object = ObjectFactory.create(object_type=OBJECT_TYPE)
         ObjectFactory.create()
 
-        response = self.client.get(self.url, {"type": OBJECT_TYPE}, **GEO_READ_KWARGS)
+        response = self.client.get(self.url, {"type": OBJECT_TYPE})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/src/objects/tests/test_geo_search.py
+++ b/src/objects/tests/test_geo_search.py
@@ -7,7 +7,6 @@ from rest_framework.test import APITestCase
 from objects.core.tests.factores import ObjectRecordFactory
 
 from .constants import POLYGON_AMSTERDAM_CENTRUM
-from .utils import GEO_WRITE_KWARGS
 
 OBJECT_TYPE = "https://example.com/objecttypes/v1/types/a6c109"
 
@@ -33,7 +32,6 @@ class GeoSearchTests(APITestCase):
                     }
                 }
             },
-            **GEO_WRITE_KWARGS,
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -63,7 +61,6 @@ class GeoSearchTests(APITestCase):
                 },
                 "type": OBJECT_TYPE,
             },
-            **GEO_WRITE_KWARGS,
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/src/objects/tests/test_object_api.py
+++ b/src/objects/tests/test_object_api.py
@@ -11,7 +11,7 @@ from rest_framework.test import APITestCase
 from objects.core.models import Object
 from objects.core.tests.factores import ObjectFactory, ObjectRecordFactory
 
-from .utils import GEO_READ_KWARGS, GEO_WRITE_KWARGS, mock_objecttype
+from .utils import mock_objecttype
 
 OBJECT_TYPE = "https://example.com/objecttypes/v1/types/a6c109"
 
@@ -28,7 +28,7 @@ class ObjectApiTests(APITestCase):
         )
         url = reverse("object-detail", args=[object.uuid])
 
-        response = self.client.get(url, **GEO_READ_KWARGS)
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -69,7 +69,7 @@ class ObjectApiTests(APITestCase):
             },
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -109,7 +109,7 @@ class ObjectApiTests(APITestCase):
             },
         }
 
-        response = self.client.put(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.put(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -154,7 +154,7 @@ class ObjectApiTests(APITestCase):
             },
         }
 
-        response = self.client.patch(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.patch(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -198,7 +198,7 @@ class ObjectApiTests(APITestCase):
         )
         url = reverse("object-history", args=[object.uuid])
 
-        response = self.client.get(url, **GEO_READ_KWARGS)
+        response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/src/objects/tests/test_validation.py
+++ b/src/objects/tests/test_validation.py
@@ -7,7 +7,7 @@ from rest_framework.test import APITestCase
 from objects.core.models import Object
 from objects.core.tests.factores import ObjectRecordFactory
 
-from .utils import GEO_READ_KWARGS, GEO_WRITE_KWARGS, mock_objecttype
+from .utils import mock_objecttype
 
 OBJECT_TYPE = "https://example.com/objecttypes/v1/types/a6c109"
 
@@ -28,7 +28,7 @@ class ObjectTypeValidationTests(APITestCase):
             },
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Object.objects.count(), 0)
@@ -53,7 +53,7 @@ class ObjectTypeValidationTests(APITestCase):
             },
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Object.objects.count(), 0)
@@ -77,7 +77,7 @@ class ObjectTypeValidationTests(APITestCase):
             },
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Object.objects.count(), 0)
@@ -93,7 +93,7 @@ class ObjectTypeValidationTests(APITestCase):
             "type": OBJECT_TYPE,
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Object.objects.count(), 0)
@@ -113,7 +113,7 @@ class ObjectTypeValidationTests(APITestCase):
             },
         }
 
-        response = self.client.post(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(Object.objects.exclude(id=record.object.id).count(), 0)
@@ -142,7 +142,7 @@ class ObjectTypeValidationTests(APITestCase):
             },
         }
 
-        response = self.client.put(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.put(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -166,7 +166,7 @@ class ObjectTypeValidationTests(APITestCase):
             "type": OBJECT_TYPE,
         }
 
-        response = self.client.patch(url, data, **GEO_WRITE_KWARGS)
+        response = self.client.patch(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/src/objects/tests/utils.py
+++ b/src/objects/tests/utils.py
@@ -1,8 +1,3 @@
-GEO_READ_KWARGS = {"HTTP_ACCEPT_CRS": "EPSG:4326"}
-
-GEO_WRITE_KWARGS = {"HTTP_ACCEPT_CRS": "EPSG:4326", "HTTP_CONTENT_CRS": "EPSG:4326"}
-
-
 def mock_objecttype(url: str) -> dict:
     return {
         "url": url,

--- a/src/objects/utils/inspectors.py
+++ b/src/objects/utils/inspectors.py
@@ -1,0 +1,13 @@
+from vng_api_common.inspectors.geojson import (
+    GeometryFieldInspector as _GeometryFieldInspector,
+)
+
+
+class GeometryFieldInspector(_GeometryFieldInspector):
+    """ don't show GEO headers since they are not required now"""
+
+    def get_request_header_parameters(self, serializer):
+        return []
+
+    def get_response_headers(self, serializer, status=None):
+        return None

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -15,38 +15,10 @@ paths:
         required: false
         schema:
           type: string
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       responses:
         '200':
           description: OK
           headers:
-            Content-Crs:
-              description: Het 'Coordinate Reference System' (CRS) van de antwoorddata.
-                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde
-                als WGS84).
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
             API-version:
               schema:
                 type: string
@@ -180,26 +152,6 @@ paths:
           type: string
           enum:
           - application/json
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       requestBody:
         $ref: '#/components/requestBodies/Object'
       responses:
@@ -344,26 +296,6 @@ paths:
           type: string
           enum:
           - application/json
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       requestBody:
         content:
           application/json:
@@ -374,14 +306,6 @@ paths:
         '200':
           description: OK
           headers:
-            Content-Crs:
-              description: Het 'Coordinate Reference System' (CRS) van de antwoorddata.
-                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde
-                als WGS84).
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
             API-version:
               schema:
                 type: string
@@ -509,26 +433,6 @@ paths:
       operationId: object_read
       description: ''
       parameters:
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       - name: If-None-Match
         in: header
         description: "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\
@@ -551,14 +455,6 @@ paths:
         '200':
           description: OK
           headers:
-            Content-Crs:
-              description: Het 'Coordinate Reference System' (CRS) van de antwoorddata.
-                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde
-                als WGS84).
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
             ETag:
               description: De ETag berekend op de response body JSON. Indien twee
                 resources exact dezelfde ETag hebben, dan zijn deze resources identiek
@@ -696,40 +592,12 @@ paths:
           type: string
           enum:
           - application/json
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       requestBody:
         $ref: '#/components/requestBodies/Object'
       responses:
         '200':
           description: OK
           headers:
-            Content-Crs:
-              description: Het 'Coordinate Reference System' (CRS) van de antwoorddata.
-                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde
-                als WGS84).
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
             API-version:
               schema:
                 type: string
@@ -873,40 +741,12 @@ paths:
           type: string
           enum:
           - application/json
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       requestBody:
         $ref: '#/components/requestBodies/Object'
       responses:
         '200':
           description: OK
           headers:
-            Content-Crs:
-              description: Het 'Coordinate Reference System' (CRS) van de antwoorddata.
-                Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde
-                als WGS84).
-              schema:
-                type: string
-                enum:
-                - EPSG:4326
             API-version:
               schema:
                 type: string
@@ -1173,26 +1013,6 @@ paths:
       operationId: object_history
       description: ''
       parameters:
-      - name: Accept-Crs
-        in: header
-        description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
-          in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default
-          (EPSG:4326 is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
-      - name: Content-Crs
-        in: header
-        description: Het 'Coordinate Reference System' (CRS) van de geometrie in de
-          vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326
-          is hetzelfde als WGS84).
-        required: true
-        schema:
-          type: string
-          enum:
-          - EPSG:4326
       - name: If-None-Match
         in: header
         description: "Voer een voorwaardelijk verzoek uit. Deze header moet \xE9\xE9\

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -28,26 +28,6 @@
                         "description": "Url reference to OBJECTTYPE in Objecttypes API",
                         "required": false,
                         "type": "string"
-                    },
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
                     }
                 ],
                 "responses": {
@@ -60,13 +40,6 @@
                             }
                         },
                         "headers": {
-                            "Content-Crs": {
-                                "description": "Het 'Coordinate Reference System' (CRS) van de antwoorddata. Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                                "type": "string",
-                                "enum": [
-                                    "EPSG:4326"
-                                ]
-                            },
                             "API-version": {
                                 "schema": {
                                     "type": "string"
@@ -227,26 +200,6 @@
                         "schema": {
                             "$ref": "#/definitions/Object"
                         }
-                    },
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
                     }
                 ],
                 "responses": {
@@ -426,26 +379,6 @@
                         "schema": {
                             "$ref": "#/definitions/ObjectSearch"
                         }
-                    },
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
                     }
                 ],
                 "responses": {
@@ -458,13 +391,6 @@
                             }
                         },
                         "headers": {
-                            "Content-Crs": {
-                                "description": "Het 'Coordinate Reference System' (CRS) van de antwoorddata. Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                                "type": "string",
-                                "enum": [
-                                    "EPSG:4326"
-                                ]
-                            },
                             "API-version": {
                                 "schema": {
                                     "type": "string"
@@ -612,26 +538,6 @@
                 "description": "",
                 "parameters": [
                     {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
                         "name": "If-None-Match",
                         "in": "header",
                         "description": "Voer een voorwaardelijk verzoek uit. Deze header moet \u00e9\u00e9n of meerdere ETag-waardes bevatten van resources die de consumer gecached heeft. Indien de waarde van de ETag van de huidige resource voorkomt in deze set, dan antwoordt de provider met een lege HTTP 304 request. Zie [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) voor meer informatie.",
@@ -656,13 +562,6 @@
                             "$ref": "#/definitions/Object"
                         },
                         "headers": {
-                            "Content-Crs": {
-                                "description": "Het 'Coordinate Reference System' (CRS) van de antwoorddata. Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                                "type": "string",
-                                "enum": [
-                                    "EPSG:4326"
-                                ]
-                            },
                             "ETag": {
                                 "description": "De ETag berekend op de response body JSON. Indien twee resources exact dezelfde ETag hebben, dan zijn deze resources identiek aan elkaar. Je kan de ETag gebruiken om caching te implementeren.",
                                 "type": "string"
@@ -827,26 +726,6 @@
                         "schema": {
                             "$ref": "#/definitions/Object"
                         }
-                    },
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
                     }
                 ],
                 "responses": {
@@ -856,13 +735,6 @@
                             "$ref": "#/definitions/Object"
                         },
                         "headers": {
-                            "Content-Crs": {
-                                "description": "Het 'Coordinate Reference System' (CRS) van de antwoorddata. Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                                "type": "string",
-                                "enum": [
-                                    "EPSG:4326"
-                                ]
-                            },
                             "API-version": {
                                 "schema": {
                                     "type": "string"
@@ -1037,26 +909,6 @@
                         "schema": {
                             "$ref": "#/definitions/Object"
                         }
-                    },
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
                     }
                 ],
                 "responses": {
@@ -1066,13 +918,6 @@
                             "$ref": "#/definitions/Object"
                         },
                         "headers": {
-                            "Content-Crs": {
-                                "description": "Het 'Coordinate Reference System' (CRS) van de antwoorddata. Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                                "type": "string",
-                                "enum": [
-                                    "EPSG:4326"
-                                ]
-                            },
                             "API-version": {
                                 "schema": {
                                     "type": "string"
@@ -1389,26 +1234,6 @@
                 "operationId": "object_history",
                 "description": "",
                 "parameters": [
-                    {
-                        "name": "Accept-Crs",
-                        "in": "header",
-                        "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
-                    {
-                        "name": "Content-Crs",
-                        "in": "header",
-                        "description": "Het 'Coordinate Reference System' (CRS) van de geometrie in de vraag (request body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
-                        "required": true,
-                        "type": "string",
-                        "enum": [
-                            "EPSG:4326"
-                        ]
-                    },
                     {
                         "name": "If-None-Match",
                         "in": "header",


### PR DESCRIPTION
This is a work-around to be able to create `ZAAKOBJECT` with Object API urls in Zaken API