### PR TITLE
:whale: Drop superuser priviliges in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,13 @@ RUN mkdir /app/log /app/config
 COPY --from=frontend-build /app/src/objects/static/css /app/src/objects/static/css
 COPY --from=frontend-build /app/src/objects/static/js /app/src/objects/static/js
 COPY ./src /app/src
+
+RUN useradd -M -u 1000 user
+RUN chown -R user /app
+
+# drop privileges
+USER user
+
 ARG COMMIT_HASH
 ARG RELEASE
 ENV GIT_SHA=${COMMIT_HASH}


### PR DESCRIPTION
to ensure that containers can be run as non-root users