### PR TITLE
Feature/filter data attrs by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/objects/static/bundles/
 # Environment
 local.py
 /env/
+/venv/
 /media/
 /static/
 /mail/

--- a/src/objects/api/filters.py
+++ b/src/objects/api/filters.py
@@ -113,7 +113,7 @@ class ObjectFilterSet(FilterSet):
 Data filtering expressions are comma-separated and are structured as follows:
 A valid parameter value has the form `key__operator__value`.
 `key` is the attribute name, `operator` is the comparison operator to be used and `value` is the attribute value.
-Note: Values can be string, numeric, or dates.
+Note: Values can be string, numeric, or dates (ISO format; YYYY-MM-DD).
 
 Valid operator values are:
 %(operator_choices)s

--- a/src/objects/api/utils.py
+++ b/src/objects/api/utils.py
@@ -8,7 +8,7 @@ def string_to_value(value: str) -> Any:
     if is_number(value):
         return float(value)
     elif is_date(value):
-        return datetime.strptime(value, "%Y-%m-%d").isoformat()
+        return datetime.strptime(value, "%Y-%m-%d")
 
     return None
 

--- a/src/objects/api/utils.py
+++ b/src/objects/api/utils.py
@@ -1,4 +1,25 @@
+from datetime import datetime
+from typing import Any
+
 from djchoices import DjangoChoices
+
+
+def string_to_value(value: str) -> Any:
+    if is_number(value):
+        return float(value)
+    elif is_date(value):
+        return datetime.strptime(value, "%Y-%m-%d").isoformat()
+
+    return None
+
+
+def is_date(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return False
+
+    return True
 
 
 def is_number(value: str) -> bool:

--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -92,7 +92,7 @@ paths:
           Data filtering expressions are comma-separated and are structured as follows:
           A valid parameter value has the form `key__operator__value`.
           `key` is the attribute name, `operator` is the comparison operator to be used and `value` is the attribute value.
-          Note: Values can be string or numeric. Dates are not supported.
+          Note: Values can be string, numeric, or dates.
 
           Valid operator values are:
           * `exact` - equal to
@@ -541,7 +541,7 @@ paths:
                       Data filtering expressions are comma-separated and are structured as follows:
                       A valid parameter value has the form `key__operator__value`.
                       `key` is the attribute name, `operator` is the comparison operator to be used and `value` is the attribute value.
-                      Note: Values can be string or numeric. Dates are not supported.
+                      Note: Values can be string, numeric, or dates.
 
                       Valid operator values are:
                       * `exact` - equal to

--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -92,7 +92,7 @@ paths:
           Data filtering expressions are comma-separated and are structured as follows:
           A valid parameter value has the form `key__operator__value`.
           `key` is the attribute name, `operator` is the comparison operator to be used and `value` is the attribute value.
-          Note: Values can be string, numeric, or dates.
+          Note: Values can be string, numeric, or dates (ISO format; YYYY-MM-DD).
 
           Valid operator values are:
           * `exact` - equal to
@@ -541,7 +541,7 @@ paths:
                       Data filtering expressions are comma-separated and are structured as follows:
                       A valid parameter value has the form `key__operator__value`.
                       `key` is the attribute name, `operator` is the comparison operator to be used and `value` is the attribute value.
-                      Note: Values can be string, numeric, or dates.
+                      Note: Values can be string, numeric, or dates (ISO format; YYYY-MM-DD).
 
                       Valid operator values are:
                       * `exact` - equal to

--- a/src/objects/api/validators.py
+++ b/src/objects/api/validators.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from objects.core.utils import check_objecttype
 
 from .constants import Operators
-from .utils import is_number
+from .utils import is_number, string_to_value
 
 
 class JsonSchemaValidator:
@@ -84,8 +84,8 @@ def validate_data_attrs(value: str):
             }
             raise serializers.ValidationError(message, code=code)
 
-        if operator != Operators.exact and not is_number(val):
-            message = _("Operator `%(operator)s` supports only numeric values") % {
-                "operator": operator
-            }
+        if operator != Operators.exact and not string_to_value(val):
+            message = _(
+                "Operator `%(operator)s` supports only dates and/or numeric values"
+            ) % {"operator": operator}
             raise serializers.ValidationError(message, code=code)

--- a/src/objects/core/models.py
+++ b/src/objects/core/models.py
@@ -4,6 +4,7 @@ import uuid
 from django.contrib.gis.db.models import GeometryField
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -82,7 +83,10 @@ class ObjectRecord(models.Model):
         help_text=_("Version of the OBJECTTYPE for data in the object record"),
     )
     data = JSONField(
-        _("data"), help_text=_("Object data, based on OBJECTTYPE"), default=dict
+        _("data"),
+        help_text=_("Object data, based on OBJECTTYPE"),
+        default=dict,
+        encoder=DjangoJSONEncoder,
     )
     start_at = models.DateField(
         _("start at"), help_text=_("Legal start date of the object record")

--- a/src/objects/tests/v1/test_filters.py
+++ b/src/objects/tests/v1/test_filters.py
@@ -195,7 +195,7 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.json(), ["Operator `lt` supports only numeric values"]
+            response.json(), ["Operator `lt` supports only dates and/or numeric values"]
         )
 
     def test_filter_invalid_operator(self):
@@ -334,8 +334,7 @@ class FilterDateTests(TokenAuthMixin, APITestCase):
     def test_filter_registration_date_detail(self):
         object = ObjectFactory.create(object_type=self.object_type)
         record1 = ObjectRecordFactory.create(
-            object=object,
-            registration_at="2020-01-01",
+            object=object, registration_at="2020-01-01",
         )
         record2 = ObjectRecordFactory.create(
             object=object, registration_at="2021-01-01"

--- a/src/objects/tests/v2/test_filters.py
+++ b/src/objects/tests/v2/test_filters.py
@@ -137,6 +137,21 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
             f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
         )
 
+    def test_filter_exact_date(self):
+        record = ObjectRecordFactory.create(
+            data={"date": "2000-11-01"}, object__object_type=self.object_type
+        )
+
+        response = self.client.get(self.url, {"data_attrs": "date__exact__2000-11-01"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0]["url"],
+            f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
+        )
+
     def test_filter_lte(self):
         record1 = ObjectRecordFactory.create(
             data={"diameter": 4}, object__object_type=self.object_type
@@ -196,6 +211,37 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json(), ["Operator `lt` supports only dates and/or numeric values"]
+        )
+
+    def test_filter_lte_date(self):
+        record = ObjectRecordFactory.create(
+            data={"date": "2000-11-01"}, object__object_type=self.object_type
+        )
+
+        response = self.client.get(self.url, {"data_attrs": "date__lte__2000-12-01"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0]["url"],
+            f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
+        )
+
+        response = self.client.get(self.url, {"data_attrs": "date__lte__2000-10-01"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(len(data), 0)
+
+        response = self.client.get(self.url, {"data_attrs": "date__lte__2000-11-01"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0]["url"],
+            f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
         )
 
     def test_filter_invalid_operator(self):

--- a/src/objects/tests/v2/test_filters.py
+++ b/src/objects/tests/v2/test_filters.py
@@ -195,7 +195,7 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.json(), ["Operator `lt` supports only numeric values"]
+            response.json(), ["Operator `lt` supports only dates and/or numeric values"]
         )
 
     def test_filter_invalid_operator(self):


### PR DESCRIPTION
Fixes #214

Allow for date filtering via data_attrs by implementing the built-in DjangoJSONEncoder as the encoder for the data field. Updated filters and validators.