### PR TITLE
add icontains to data_attrs operators

### DIFF
--- a/src/objects/api/constants.py
+++ b/src/objects/api/constants.py
@@ -9,3 +9,4 @@ class Operators(DjangoChoices):
     gte = ChoiceItem("gte", _("greater than or equal to"))
     lt = ChoiceItem("lt", _("lower than"))
     lte = ChoiceItem("lte", _("lower than or equal to"))
+    icontains = ChoiceItem("icontains", _("case-insensitive containment"))

--- a/src/objects/api/constants.py
+++ b/src/objects/api/constants.py
@@ -9,4 +9,6 @@ class Operators(DjangoChoices):
     gte = ChoiceItem("gte", _("greater than or equal to"))
     lt = ChoiceItem("lt", _("lower than"))
     lte = ChoiceItem("lte", _("lower than or equal to"))
-    icontains = ChoiceItem("icontains", _("case-insensitive containment"))
+    icontains = ChoiceItem(
+        "icontains", _("case-insensitive containment, can be used for strings.")
+    )

--- a/src/objects/api/constants.py
+++ b/src/objects/api/constants.py
@@ -10,5 +10,5 @@ class Operators(DjangoChoices):
     lt = ChoiceItem("lt", _("lower than"))
     lte = ChoiceItem("lte", _("lower than or equal to"))
     icontains = ChoiceItem(
-        "icontains", _("case-insensitive containment, can be used for strings.")
+        "icontains", _("case-insensitive partial matches on string values.")
     )

--- a/src/objects/api/filters.py
+++ b/src/objects/api/filters.py
@@ -12,12 +12,7 @@ from vng_api_common.filtersets import FilterSet
 from objects.core.models import Object, ObjectType
 
 from .constants import Operators
-from .utils import (
-    display_choice_values_for_help_text,
-    is_date,
-    is_number,
-    string_to_value,
-)
+from .utils import display_choice_values_for_help_text, string_to_value
 from .validators import validate_data_attrs
 
 
@@ -143,14 +138,13 @@ should be used. If `height` is nested inside `dimensions` attribute, query shoul
             if operator == "exact":
                 #  for exact operator try to filter on string and numeric values
                 in_vals = [val]
-                if real_value:
+                if real_value != value:
                     in_vals.append(real_value)
                 queryset = queryset.filter(
                     **{f"records__data__{variable}__in": in_vals}
                 )
 
             else:
-                # only numeric
                 queryset = queryset.filter(
                     **{f"records__data__{variable}__{operator}": real_value}
                 )

--- a/src/objects/api/filters.py
+++ b/src/objects/api/filters.py
@@ -112,6 +112,7 @@ Note: Values can be string, numeric, or dates (ISO format; YYYY-MM-DD).
 
 Valid operator values are:
 %(operator_choices)s
+
 `value` may not contain double underscore or comma characters.
 `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
 

--- a/src/objects/api/utils.py
+++ b/src/objects/api/utils.py
@@ -10,7 +10,7 @@ def string_to_value(value: str) -> Any:
     elif is_date(value):
         return datetime.strptime(value, "%Y-%m-%d")
 
-    return None
+    return value
 
 
 def is_date(value: str) -> bool:

--- a/src/objects/api/v1/openapi.yaml
+++ b/src/objects/api/v1/openapi.yaml
@@ -105,7 +105,7 @@ paths:
           * `gte` - greater than or equal to
           * `lt` - lower than
           * `lte` - lower than or equal to
-          * `icontains` - case-insensitive containment, can be used for strings.
+          * `icontains` - case-insensitive partial matches on string values.
 
           `value` may not contain double underscore or comma characters.
           `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
@@ -534,7 +534,7 @@ paths:
                       * `gte` - greater than or equal to
                       * `lt` - lower than
                       * `lte` - lower than or equal to
-                      * `icontains` - case-insensitive containment, can be used for strings.
+                      * `icontains` - case-insensitive partial matches on string values.
 
                       `value` may not contain double underscore or comma characters.
                       `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.

--- a/src/objects/api/v1/openapi.yaml
+++ b/src/objects/api/v1/openapi.yaml
@@ -105,6 +105,8 @@ paths:
           * `gte` - greater than or equal to
           * `lt` - lower than
           * `lte` - lower than or equal to
+          * `icontains` - case-insensitive containment, can be used for strings.
+
           `value` may not contain double underscore or comma characters.
           `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
 
@@ -532,6 +534,8 @@ paths:
                       * `gte` - greater than or equal to
                       * `lt` - lower than
                       * `lte` - lower than or equal to
+                      * `icontains` - case-insensitive containment, can be used for strings.
+
                       `value` may not contain double underscore or comma characters.
                       `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
 

--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -105,6 +105,8 @@ paths:
           * `gte` - greater than or equal to
           * `lt` - lower than
           * `lte` - lower than or equal to
+          * `icontains` - case-insensitive containment, can be used for strings.
+
           `value` may not contain double underscore or comma characters.
           `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
 
@@ -564,6 +566,8 @@ paths:
                       * `gte` - greater than or equal to
                       * `lt` - lower than
                       * `lte` - lower than or equal to
+                      * `icontains` - case-insensitive containment, can be used for strings.
+
                       `value` may not contain double underscore or comma characters.
                       `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
 

--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -105,7 +105,7 @@ paths:
           * `gte` - greater than or equal to
           * `lt` - lower than
           * `lte` - lower than or equal to
-          * `icontains` - case-insensitive containment, can be used for strings.
+          * `icontains` - case-insensitive partial matches on string values.
 
           `value` may not contain double underscore or comma characters.
           `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.
@@ -566,7 +566,7 @@ paths:
                       * `gte` - greater than or equal to
                       * `lt` - lower than
                       * `lte` - lower than or equal to
-                      * `icontains` - case-insensitive containment, can be used for strings.
+                      * `icontains` - case-insensitive partial matches on string values.
 
                       `value` may not contain double underscore or comma characters.
                       `key` may not contain comma characters and includes double underscore only if it indicates nested attributes.

--- a/src/objects/api/validators.py
+++ b/src/objects/api/validators.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from objects.core.utils import check_objecttype
 
 from .constants import Operators
-from .utils import is_number, string_to_value
+from .utils import string_to_value
 
 
 class JsonSchemaValidator:
@@ -81,7 +81,9 @@ def validate_data_attrs(value: str):
             }
             raise serializers.ValidationError(message, code=code)
 
-        if operator != Operators.exact and not string_to_value(val):
+        if operator not in (Operators.exact, Operators.icontains) and isinstance(
+            string_to_value(val), str
+        ):
             message = _(
                 "Operator `%(operator)s` supports only dates and/or numeric values"
             ) % {"operator": operator}

--- a/src/objects/tests/v1/test_filters.py
+++ b/src/objects/tests/v1/test_filters.py
@@ -266,6 +266,27 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
             f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
         )
 
+    def test_filter_icontains_string(self):
+        record = ObjectRecordFactory.create(
+            data={"name": "Something important"}, object__object_type=self.object_type
+        )
+        ObjectRecordFactory.create(
+            data={"name": "Nothing important"}, object__object_type=self.object_type
+        )
+        ObjectRecordFactory.create(data={}, object__object_type=self.object_type)
+
+        response = self.client.get(self.url, {"data_attrs": "name__icontains__some"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0]["url"],
+            f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
+        )
+
 
 class FilterDateTests(TokenAuthMixin, APITestCase):
     @classmethod

--- a/src/objects/tests/v2/test_filters.py
+++ b/src/objects/tests/v2/test_filters.py
@@ -312,6 +312,27 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
             f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
         )
 
+    def test_filter_icontains_string(self):
+        record = ObjectRecordFactory.create(
+            data={"name": "Something important"}, object__object_type=self.object_type
+        )
+        ObjectRecordFactory.create(
+            data={"name": "Nothing important"}, object__object_type=self.object_type
+        )
+        ObjectRecordFactory.create(data={}, object__object_type=self.object_type)
+
+        response = self.client.get(self.url, {"data_attrs": "name__icontains__some"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(
+            data[0]["url"],
+            f"http://testserver{reverse('object-detail', args=[record.object.uuid])}",
+        )
+
 
 class FilterDateTests(TokenAuthMixin, APITestCase):
     @classmethod


### PR DESCRIPTION
fixes #235 


**Upd.** 

Quick performance test which shows that the performance of `data_attrs` query param with `icontains` is in line with others:
```
 Name                                                          # reqs      # fails  |     Avg     Min     Max  Median  |   req/s failures/s
--------------------------------------------------------------------------------------------------------------------------------------------
 GET Retrieve all objects                                         215     0(0.00%)  |     175     113     373     140  |    0.72    0.00
 *GET Retrieve by data_attrs with icontains                       212     0(0.00%)  |      96      73     171      93  |    0.71    0.00
 GET Retrieve by data_attrs with lte                              193     0(0.00%)  |     110      87     206     100  |    0.64    0.00
 GET Retrieve by data_icontains                                   214     0(0.00%)  |     100      79     209      95  |    0.71    0.00
 GET Retrieve by geo coordinates                                  195     0(0.00%)  |     168     114     361     140  |    0.65    0.00
 GET Retrieve single object                                       184     0(0.00%)  |      68      54     180      66  |    0.61    0.00
--------------------------------------------------------------------------------------------------------------------------------------------
 Aggregated                                                      1213     0(0.00%)  |     120      54     373     100  |    4.04    0.00