### PR TITLE
Ticket 282 updating starting at value results in 500

### DIFF
--- a/src/objects/core/models.py
+++ b/src/objects/core/models.py
@@ -69,7 +69,7 @@ class Object(models.Model):
 
     @property
     def last_record(self):
-        return self.records.order_by("-start_at", "-index").first()
+        return self.records.order_by("-index").first()
 
     @property
     def record(self):


### PR DESCRIPTION
Fixes #282

Added a test case to recreate the initial problem described on issue 282

1. Create an Object with some date for startAt
2. Update this Object with a date before the startAt in step 1
3. Attempt to update this Object again, resulting in a 500 error:
`django.db.utils.IntegrityError: duplicate key value violates unique constraint "core_objectrecord_correct_id_key"
DETAIL:  Key (correct_id)=(2) already exists.`

After debugging discovered that the issue was the last_record function of the Object model.
Where we ordered on startAt and -index.

The solution to this problem was to remove the startAt from the orderBy.
