### PR TITLE
:bug: Unique name for session ID cookie

### DIFF
--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -302,6 +302,8 @@ AUTHENTICATION_BACKENDS = [
     "mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
 ]
 
+SESSION_COOKIE_NAME = "objects_sessionid"
+
 LOGIN_REDIRECT_URL = reverse_lazy("admin:index")
 LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 


### PR DESCRIPTION
previously the `SESSION_COOKIE_NAME` for objects and objecttypes were the same, making it impossible to be logged into both apps simultaneously