### PR TITLE
:bug: Fix date parsing in API filtering

### DIFF
--- a/src/objects/api/filter_backends.py
+++ b/src/objects/api/filter_backends.py
@@ -22,7 +22,7 @@ class OrderingBackend(OrderingFilter):
     )
 
     def get_valid_fields(self, queryset, view, context={}):
-        """ add nested fields to available fields for ordering"""
+        """add nested fields to available fields for ordering"""
         valid_fields = getattr(view, "ordering_fields", self.ordering_fields)
 
         if valid_fields is None:
@@ -102,7 +102,7 @@ class OrderingBackend(OrderingFilter):
         return getattr(view, "json_field", self.json_field)
 
     def get_db_ordering(self, request, queryset, view) -> list:
-        """ get serializer ordering fields and convert them to db fields"""
+        """get serializer ordering fields and convert them to db fields"""
         ordering = self.get_ordering(request, queryset, view)
         ordering = ordering or []
 

--- a/src/objects/api/utils.py
+++ b/src/objects/api/utils.py
@@ -1,10 +1,10 @@
 from datetime import date
-from typing import Any
+from typing import Union
 
 from djchoices import DjangoChoices
 
 
-def string_to_value(value: str) -> Any:
+def string_to_value(value: str) -> Union[str, float, date]:
     if is_number(value):
         return float(value)
     elif is_date(value):

--- a/src/objects/api/utils.py
+++ b/src/objects/api/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from typing import Any
 
 from djchoices import DjangoChoices
@@ -8,14 +8,14 @@ def string_to_value(value: str) -> Any:
     if is_number(value):
         return float(value)
     elif is_date(value):
-        return datetime.strptime(value, "%Y-%m-%d")
+        return date.fromisoformat(value)
 
     return value
 
 
 def is_date(value: str) -> bool:
     try:
-        datetime.strptime(value, "%Y-%m-%d")
+        date.fromisoformat(value)
     except ValueError:
         return False
 

--- a/src/objects/tests/v2/test_filters.py
+++ b/src/objects/tests/v2/test_filters.py
@@ -379,18 +379,21 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
 
     def test_filter_date_field_gte(self):
         record = ObjectRecordFactory.create(
-            data={"dateField": "2000-10-10"},
-            object__object_type=self.object_type
+            data={"dateField": "2000-10-10"}, object__object_type=self.object_type
         )
 
-        response = self.client.get(self.url, {"data_attrs": "dateField__gte__2000-10-10"})
+        response = self.client.get(
+            self.url, {"data_attrs": "dateField__gte__2000-10-10"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()["results"]
 
         self.assertEqual(len(data), 1)
 
-        response = self.client.get(self.url, {"data_attrs": "dateField__gte__2000-10-11"})
+        response = self.client.get(
+            self.url, {"data_attrs": "dateField__gte__2000-10-11"}
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()["results"]

--- a/src/objects/tests/v2/test_filters.py
+++ b/src/objects/tests/v2/test_filters.py
@@ -377,6 +377,26 @@ class FilterDataAttrsTests(TokenAuthMixin, APITestCase):
         data = response.json()["results"]
         self.assertEqual(len(data), 0)
 
+    def test_filter_date_field_gte(self):
+        record = ObjectRecordFactory.create(
+            data={"dateField": "2000-10-10"},
+            object__object_type=self.object_type
+        )
+
+        response = self.client.get(self.url, {"data_attrs": "dateField__gte__2000-10-10"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(len(data), 1)
+
+        response = self.client.get(self.url, {"data_attrs": "dateField__gte__2000-10-11"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()["results"]
+
+        self.assertEqual(len(data), 0)
+
 
 class FilterDateTests(TokenAuthMixin, APITestCase):
     @classmethod

--- a/src/objects/utils/serializers.py
+++ b/src/objects/utils/serializers.py
@@ -36,13 +36,13 @@ def build_spec_field(spec, name, value, ui):
 
 
 def get_field_names(data: Dict[str, fields.Field]) -> List[str]:
-    """ return list of names for all serializer fields. Supports nesting"""
+    """return list of names for all serializer fields. Supports nesting"""
     names_and_sources = get_field_names_and_sources(data)
     return [name for name, source in names_and_sources]
 
 
 def get_field_names_and_sources(data: Dict[str, fields.Field]) -> List[Tuple[str, str]]:
-    """ return list of (name, source) for all serializer fields. Supports nesting"""
+    """return list of (name, source) for all serializer fields. Supports nesting"""
     names_and_sources = []
     for key, value in data.items():
         if isinstance(value, dict):


### PR DESCRIPTION
Using a `datetime` object instead of the `date` one can result to a wrong filtering behavior in some cases.

Suppose we have a few `ObjectRecord` instances, with a date field in their data. Trying to filter on this field with a `datetime` object and a `gte`/`lte` lookup will result in the following:

 ```python
>>> ObjectRecord.objects.filter(
    data__myDateField__gte=datetime.strptime("2000-02-20", "%Y-%m-%d")
).order_by("data__myDateField").first().data["myDateField"]

'2001-01-10"  # Not the correct object
```

Using a `date` object instead:

```python
>>> ObjectRecord.objects.filter(
    data__myDateField__gte=date.fromisoformat("2000-02-20")
).order_by("data__myDateField").first().data["myDateField"]

'2000-02-00'  # gte lookup works as excepted
```