### PR TITLE
:bug: Initial token value set on Permission admin

### DIFF
--- a/src/objects/api/filter_backends.py
+++ b/src/objects/api/filter_backends.py
@@ -22,7 +22,7 @@ class OrderingBackend(OrderingFilter):
     )
 
     def get_valid_fields(self, queryset, view, context={}):
-        """ add nested fields to available fields for ordering"""
+        """add nested fields to available fields for ordering"""
         valid_fields = getattr(view, "ordering_fields", self.ordering_fields)
 
         if valid_fields is None:
@@ -102,7 +102,7 @@ class OrderingBackend(OrderingFilter):
         return getattr(view, "json_field", self.json_field)
 
     def get_db_ordering(self, request, queryset, view) -> list:
-        """ get serializer ordering fields and convert them to db fields"""
+        """get serializer ordering fields and convert them to db fields"""
         ordering = self.get_ordering(request, queryset, view)
         ordering = ordering or []
 

--- a/src/objects/token/admin.py
+++ b/src/objects/token/admin.py
@@ -46,7 +46,7 @@ class PermissionAdmin(admin.ModelAdmin):
         if request.method == "POST":
             form = ModelForm(request.POST, request.FILES, instance=obj)
         else:
-            form = ModelForm(instance=obj)
+            form = ModelForm(instance=obj, initial={"token_auth": request.GET.get("token_auth")})
         form.is_valid()
 
         values = {field.name: field.value() for field in form}
@@ -101,6 +101,7 @@ class PermissionAdmin(admin.ModelAdmin):
 
 class PermissionInline(EditInlineAdminMixin, admin.TabularInline):
     model = Permission
+    fk_name = "token_auth"
     fields = ("object_type", "mode", "use_fields", "fields")
 
 

--- a/src/objects/token/admin.py
+++ b/src/objects/token/admin.py
@@ -46,7 +46,9 @@ class PermissionAdmin(admin.ModelAdmin):
         if request.method == "POST":
             form = ModelForm(request.POST, request.FILES, instance=obj)
         else:
-            form = ModelForm(instance=obj, initial={"token_auth": request.GET.get("token_auth")})
+            form = ModelForm(
+                instance=obj, initial={"token_auth": request.GET.get("token_auth")}
+            )
         form.is_valid()
 
         values = {field.name: field.value() for field in form}

--- a/src/objects/utils/serializers.py
+++ b/src/objects/utils/serializers.py
@@ -36,13 +36,13 @@ def build_spec_field(spec, name, value, ui):
 
 
 def get_field_names(data: Dict[str, fields.Field]) -> List[str]:
-    """ return list of names for all serializer fields. Supports nesting"""
+    """return list of names for all serializer fields. Supports nesting"""
     names_and_sources = get_field_names_and_sources(data)
     return [name for name, source in names_and_sources]
 
 
 def get_field_names_and_sources(data: Dict[str, fields.Field]) -> List[Tuple[str, str]]:
-    """ return list of (name, source) for all serializer fields. Supports nesting"""
+    """return list of (name, source) for all serializer fields. Supports nesting"""
     names_and_sources = []
     for key, value in data.items():
         if isinstance(value, dict):


### PR DESCRIPTION
As `fk_name` wasn't set on `PermissionInline` (and needs to be set as the `Permission` model has multiple foreign keys), the url query parameter was incorrect when trying to add a permission from a token auth. The query parameter is now correct and the initial value on the form is set correctly