### PR TITLE
:rocket: ensuring docker-compose-quickstart runs

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=objects.conf.docker
       - SECRET_KEY=${SECRET_KEY:-1(@f(-6s_u(5fd&1sg^uvu2s(c-9sapw)1era8q&)g)h@cwxxg}
+       - ALLOWED_HOSTS=localhost
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
Gezien in #313 en vanuit CI, docker-compose-quickstart start niet meer (goed) vanuit master aangezien ALLOWED_HOSTS=localhost ontbreekt.