### PR TITLE
⬆️  Upgrade pip packages

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -230,7 +230,7 @@ requests==2.25.1
     #   requests-mock
     #   vng-api-common
     #   zgw-consumers
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.7
     # via ruamel.yaml
 ruamel.yaml==0.17.4
     # via drf-yasg
@@ -267,7 +267,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.21
     # via -r requirements/base.in
 vng-api-common[markdown_docs]==1.6.4
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -344,7 +344,7 @@ requests==2.25.1
     #   requests-mock
     #   vng-api-common
     #   zgw-consumers
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.7
     # via
     #   -r requirements/base.txt
     #   ruamel.yaml
@@ -401,7 +401,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.21
     # via -r requirements/base.txt
 vng-api-common[markdown_docs]==1.6.4
     # via -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -412,7 +412,7 @@ requests==2.25.1
     #   sphinx
     #   vng-api-common
     #   zgw-consumers
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.7
     # via
     #   -r requirements/ci.txt
     #   ruamel.yaml
@@ -503,7 +503,7 @@ urllib3==1.26.6
     #   elastic-apm
     #   requests
     #   sentry-sdk
-uwsgi==2.0.19.1
+uwsgi==2.0.21
     # via -r requirements/ci.txt
 vng-api-common[markdown_docs]==1.6.4
     # via -r requirements/ci.txt


### PR DESCRIPTION
Patch Tuesday,

When you try to install the requirements from base.txt it gives you an error. This is because an older version of the packages: **uwsgi & ruamel yaml clib**

In this pull request I updated the dependencies to the latest version, so it doesn't give you an error when installing.