### PR TITLE
Add email environment variables

### DIFF
--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -366,6 +366,20 @@ IPWARE_META_PRECEDENCE_ORDER = (
     "REMOTE_ADDR",
 )
 
+#
+# Sending EMAIL
+#
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config(
+    "EMAIL_PORT", default=25
+)  # disabled on Google Cloud, use 487 instead
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False)
+EMAIL_TIMEOUT = 10
+
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", "objects@example.com")
+
 # Sentry SDK
 SENTRY_DSN = config("SENTRY_DSN", None)
 

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -203,9 +203,6 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 
 FIXTURE_DIRS = (os.path.join(DJANGO_PROJECT_DIR, "fixtures"),)
 
-DEFAULT_FROM_EMAIL = "objects@example.com"
-EMAIL_TIMEOUT = 10
-
 LOGGING_DIR = os.path.join(BASE_DIR, "log")
 
 LOGGING = {


### PR DESCRIPTION
Fix #321 

Not sure if we want to use `django_yubin.backends.QueuedEmailBackend` as openforms e.g.