### PR TITLE
:green_heart: update demodata with token model change

### DIFF
--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,8 +15,9 @@ jobs:
         run: docker-compose -f docker-compose-qs.yml up -d
       - name: Wait until DB container starts
         run: sleep 10
-      - name: Load fixtures
-        run: docker-compose -f docker-compose-qs.yml exec -T web src/manage.py loaddata demodata
+#        TODO uncomment when correct fixtures are uploaded into dockerhub inside docker image
+#      - name: Load fixtures
+#        run: docker-compose -f docker-compose-qs.yml exec -T web src/manage.py loaddata demodata
       - name: Create superuser
         run: docker-compose -f docker-compose-qs.yml exec -T web src/manage.py createsuperuser --username admin --email admin@admin.nl --no-input
       - name: Check main page

--- a/src/objects/fixtures/demodata.json
+++ b/src/objects/fixtures/demodata.json
@@ -772,20 +772,21 @@
 },
 {
     "model": "token.tokenauth",
-    "pk": "cd63e158f3aca276ef284e3033d020a22899c728",
+    "pk": 1,
     "fields": {
         "contact_person": "test",
         "email": "let@me.test",
         "organization": "",
         "last_modified": "2020-12-23T11:43:16.820Z",
-        "created": "2020-12-22T16:27:00.751Z"
+        "created": "2020-12-22T16:27:00.751Z",
+        "token": "cd63e158f3aca276ef284e3033d020a22899c728"
     }
 },
 {
     "model": "token.permission",
     "pk": 1,
     "fields": {
-        "token_auth": "cd63e158f3aca276ef284e3033d020a22899c728",
+        "token_auth": 1,
         "object_type": 2,
         "mode": "read_and_write"
     }
@@ -794,7 +795,7 @@
     "model": "token.permission",
     "pk": 2,
     "fields": {
-        "token_auth": "cd63e158f3aca276ef284e3033d020a22899c728",
+        "token_auth": 1,
         "object_type": 1,
         "mode": "read_and_write"
     }


### PR DESCRIPTION
The goal of this PR to fix CI in master branch and make it green again. 

**Explanation why it is broken:**
* We have quick-start CI workflow which uses Objects API image from docker hub and fixtures inside this image
* In the PR #397 the structure of Token model was changed, but the related fixtures were not updated
* The CI was green in the PR because quick-start action uses docker image from docker hub with old Token model structure
* After the PR was merged the docker image on docker hub was updated, so now we have a docker image with 'latest' tag where demodata fixture and token model have different structures. 
* So to fix it we need to publish a new docker image with updated fixture but to do so we need green CI
* Therefore loading fixtures is temporarily disabled until the fixtures are updated in the docker image on doker hub