### PR TITLE
Documented required CACHE_DEFAULT environment parameter

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -29,6 +29,8 @@ Required settings
   Defaults to ``*`` for the ``docker`` environment and defaults to
   ``127.0.0.1,localhost`` for the ``dev`` environment.
 
+* ``CACHE_DEFAULT``: A Redis cache driver is required. Defaults to ``redis:6379/0``.
+
 Common settings
 ---------------
 


### PR DESCRIPTION
Since objects-api:2.3.1 and objecttypes-api:2.2.0 a Redis instance is required for caching the backend. Since then the CACHE_DEFAULT env parameter is required which was not yet documented.

