### PR TITLE
disable configuration steps by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - DISABLE_2FA=${DISABLE_2FA:-yes}
       - SUBPATH=${SUBPATH}
       # setup_configuration env vars
+      - SITES_CONFIG_ENABLE=yes
       - OBJECTS_DOMAIN=web:8000
       - OBJECTS_ORGANIZATION=Objects
       - OBJECTS_OBJECTTYPES_CONFIG_ENABLE=false

--- a/docs/installation/config_cli.rst
+++ b/docs/installation/config_cli.rst
@@ -82,7 +82,7 @@ Sites configuration
 
 Configure the domain where Objects API is hosted
 
-* ``SITES_CONFIG_ENABLE``: enable Site configuration. Defaults to ``True``.
+* ``SITES_CONFIG_ENABLE``: enable Site configuration. Defaults to ``False``.
 * ``OBJECTTYPES_DOMAIN``:  a ``[host]:[port]`` or ``[host]`` value. Required.
 * ``OBJECTTYPES_ORGANIZATION``: name of Objecttypes API organization. Required.
 
@@ -93,7 +93,7 @@ Objects API uses Objecttypes API to validate data against JSON schemas, therefor
 it should be able to request Objecttypes API.
 
 * ``OBJECTS_OBJECTTYPES_CONFIG_ENABLE``: enable Objecttypes configuration. Defaults
-  to ``True``.
+  to ``False``.
 * ``OBJECTTYPES_API_ROOT``: full URL to the Objecttypes API root, for example
   ``https://objecttypes.gemeente.local/api/v1/``. Required.
 * ``OBJECTTYPES_API_OAS``: full URL to the Objecttypes OpenAPI specification.
@@ -104,7 +104,7 @@ Demo user configuration
 
 The similar configuration as in Objects API.
 
-* ``DEMO_CONFIG_ENABLE``: enable demo user configuration. Defaults to the value of the ``DEBUG`` setting.
+* ``DEMO_CONFIG_ENABLE``: enable demo user configuration. Defaults to ``False``.
 * ``DEMO_PERSON``: demo user contact person. Required.
 * ``DEMO_EMAIL``: demo user email. Required.
 * ``DEMO_TOKEN``: demo token. Required.

--- a/docs/installation/config_cli.rst
+++ b/docs/installation/config_cli.rst
@@ -41,7 +41,7 @@ Sites configuration
 
 Configure the domain where Objects API is hosted
 
-* ``SITES_CONFIG_ENABLE``: enable Site configuration. Defaults to ``True``.
+* ``SITES_CONFIG_ENABLE``: enable Site configuration. Defaults to ``False``.
 * ``OBJECTS_DOMAIN``:  a ``[host]:[port]`` or ``[host]`` value. Required.
 * ``OBJECTS_ORGANIZATION``: name of Objects API organization. Required.
 
@@ -52,7 +52,7 @@ Objects API uses Objecttypes API to validate data against JSON schemas, therefor
 it should be able to request Objecttypes API.
 
 * ``OBJECTS_OBJECTTYPES_CONFIG_ENABLE``: enable Objecttypes configuration. Defaults
-  to ``True``.
+  to ``False``.
 * ``OBJECTTYPES_API_ROOT``: full URL to the Objecttypes API root, for example
   ``https://objecttypes.gemeente.local/api/v1/``. Required.
 * ``OBJECTTYPES_API_OAS``: full URL to the Objecttypes OpenAPI specification.
@@ -66,7 +66,7 @@ Demo user configuration
 Demo user can be created to check if Objects API work. It has superuser permissions,
 so its creation is not recommended on production environment.
 
-* ``DEMO_CONFIG_ENABLE``: enable demo user configuration. Defaults to the value of the ``DEBUG`` setting.
+* ``DEMO_CONFIG_ENABLE``: enable demo user configuration. Defaults to ``False``.
 * ``DEMO_PERSON``: demo user contact person. Required.
 * ``DEMO_EMAIL``: demo user email. Required.
 * ``DEMO_TOKEN``: demo token. Required.

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -100,12 +100,12 @@ SETUP_CONFIGURATION_STEPS = [
 
 # setup_configuration command
 # sites config
-SITES_CONFIG_ENABLE = config("SITES_CONFIG_ENABLE", default=True, add_to_docs=False)
+SITES_CONFIG_ENABLE = config("SITES_CONFIG_ENABLE", default=False, add_to_docs=False)
 OBJECTS_DOMAIN = config("OBJECTS_DOMAIN", "", add_to_docs=False)
 OBJECTS_ORGANIZATION = config("OBJECTS_ORGANIZATION", "", add_to_docs=False)
 # objecttypes config
 OBJECTS_OBJECTTYPES_CONFIG_ENABLE = config(
-    "OBJECTS_OBJECTTYPES_CONFIG_ENABLE", default=True, add_to_docs=False
+    "OBJECTS_OBJECTTYPES_CONFIG_ENABLE", default=False, add_to_docs=False
 )
 OBJECTTYPES_API_ROOT = config("OBJECTTYPES_API_ROOT", "", add_to_docs=False)
 if OBJECTTYPES_API_ROOT and not OBJECTTYPES_API_ROOT.endswith("/"):
@@ -117,7 +117,7 @@ OBJECTTYPES_API_OAS = config(
 )
 OBJECTS_OBJECTTYPES_TOKEN = config("OBJECTS_OBJECTTYPES_TOKEN", "", add_to_docs=False)
 # Demo User Configuration
-DEMO_CONFIG_ENABLE = config("DEMO_CONFIG_ENABLE", default=DEBUG, add_to_docs=False)
+DEMO_CONFIG_ENABLE = config("DEMO_CONFIG_ENABLE", default=False, add_to_docs=False)
 DEMO_TOKEN = config("DEMO_TOKEN", "", add_to_docs=False)
 DEMO_PERSON = config("DEMO_PERSON", "", add_to_docs=False)
 DEMO_EMAIL = config("DEMO_EMAIL", "", add_to_docs=False)

--- a/src/objects/tests/commands/test_setup_configuration.py
+++ b/src/objects/tests/commands/test_setup_configuration.py
@@ -17,8 +17,10 @@ from ..utils import mock_service_oas_get
 
 
 @override_settings(
+    SITES_CONFIG_ENABLE=True,
     OBJECTS_DOMAIN="objects.example.com",
     OBJECTS_ORGANIZATION="ACME",
+    OBJECTS_OBJECTTYPES_CONFIG_ENABLE=True,
     OBJECTTYPES_API_ROOT="https://objecttypes.example.com/api/v2/",
     OBJECTTYPES_API_OAS="https://objecttypes.example.com/api/v2/schema/openapi.yaml",
     OBJECTS_OBJECTTYPES_TOKEN="some-random-string",


### PR DESCRIPTION
Fixes https://github.com/maykinmedia/django-setup-configuration/issues/10 (Objects API part)

