### PR TITLE
[#483] add support for mozilla django OIDC db config

### DIFF
--- a/bin/setup_configuration.sh
+++ b/bin/setup_configuration.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# setup initial configuration using an yaml file
+# setup initial configuration using a yaml file
 # Run this script from the root of the repository
 
 set -e

--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -35,9 +35,11 @@ objecttypes:
 
 oidc_db_config_enable: true
 oidc_db_config_admin_auth:
-  oidc_rp_client_id: client-id
-  oidc_rp_client_secret: secret
-  endpoint_config:
-    oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
-    oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
-    oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+  items:
+    - identifier: admin-oidc
+      oidc_rp_client_id: client-id
+      oidc_rp_client_secret: secret
+      endpoint_config:
+        oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+        oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+        oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -43,3 +43,6 @@ oidc_db_config_admin_auth:
         oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
         oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
         oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+
+      # workaround for https://github.com/maykinmedia/django-setup-configuration/issues/27
+      userinfo_claims_source: id_token

--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -32,3 +32,12 @@ objecttypes:
     - uuid: b427ef84-189d-43aa-9efd-7bb2c459e281
       name: Object Type 1
       service_identifier: objecttypes-api
+
+oidc_db_config_enable: true
+oidc_db_config_admin_auth:
+  oidc_rp_client_id: client-id
+  oidc_rp_client_secret: secret
+  endpoint_config:
+    oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+    oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+    oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo

--- a/docs/installation/config_cli.rst
+++ b/docs/installation/config_cli.rst
@@ -125,6 +125,9 @@ Create or update the (single) YAML configuration file with your settings:
           oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
           oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
           oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
+
+      # workaround for https://github.com/maykinmedia/django-setup-configuration/issues/27
+      userinfo_claims_source: id_token
    ...
 
 More details about configuring mozilla-django-oidc-db through ``setup_configuration``

--- a/docs/installation/config_cli.rst
+++ b/docs/installation/config_cli.rst
@@ -110,6 +110,24 @@ Tokens configuration
 Mozilla-django-oidc-db
 ----------------------
 
+Create or update the (single) YAML configuration file with your settings:
+
+.. code-block:: yaml
+
+   ...
+    oidc_db_config_enable: true
+    oidc_db_config_admin_auth:
+    items:
+      - identifier: admin-oidc
+        oidc_rp_client_id: client-id
+        oidc_rp_client_secret: secret
+        endpoint_config:
+          oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
+   ...
+
+More details about configuring mozilla-django-oidc-db through ``setup_configuration``
+can be found at the _`documentation`: https://mozilla-django-oidc-db.readthedocs.io/en/latest/setup_configuration.html.
+
 Sites configuration
 -------------------
 

--- a/docs/installation/config_cli.rst
+++ b/docs/installation/config_cli.rst
@@ -122,7 +122,9 @@ Create or update the (single) YAML configuration file with your settings:
         oidc_rp_client_id: client-id
         oidc_rp_client_secret: secret
         endpoint_config:
-          oidc_op_discovery_endpoint: https://keycloak.local/protocol/openid-connect/
+          oidc_op_authorization_endpoint: https://example.com/realms/test/protocol/openid-connect/auth
+          oidc_op_token_endpoint: https://example.com/realms/test/protocol/openid-connect/token
+          oidc_op_user_endpoint: https://example.com/realms/test/protocol/openid-connect/userinfo
    ...
 
 More details about configuring mozilla-django-oidc-db through ``setup_configuration``

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,3 +8,4 @@ furl
 # Common ground libraries
 notifications-api-common[setup-configuration]
 zgw-consumers[setup-configuration]
+mozilla-django-oidc-db[setup-configuration]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,6 +155,7 @@ django-sessionprofile==3.0.0
     # via open-api-framework
 django-setup-configuration==0.4.0
     # via
+    #   mozilla-django-oidc-db
     #   notifications-api-common
     #   open-api-framework
     #   zgw-consumers
@@ -242,8 +243,10 @@ maykin-2fa==1.0.1
     # via open-api-framework
 mozilla-django-oidc==4.0.0
     # via mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
-    # via open-api-framework
+mozilla-django-oidc-db[setup-configuration]==0.21.1
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 notifications-api-common[setup-configuration]==0.4.0
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -242,6 +242,7 @@ django-sessionprofile==3.0.0
 django-setup-configuration==0.4.0
     # via
     #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
     #   notifications-api-common
     #   open-api-framework
     #   zgw-consumers
@@ -398,7 +399,7 @@ mozilla-django-oidc==4.0.0
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.21.1
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -257,6 +257,7 @@ django-sessionprofile==3.0.0
 django-setup-configuration==0.4.0
     # via
     #   -r requirements/base.txt
+    #   mozilla-django-oidc-db
     #   notifications-api-common
     #   open-api-framework
     #   zgw-consumers
@@ -420,7 +421,7 @@ mozilla-django-oidc==4.0.0
     # via
     #   -r requirements/base.txt
     #   mozilla-django-oidc-db
-mozilla-django-oidc-db==0.19.0
+mozilla-django-oidc-db[setup-configuration]==0.21.1
     # via
     #   -r requirements/base.txt
     #   open-api-framework

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -87,4 +87,6 @@ SETUP_CONFIGURATION_STEPS = (
     "zgw_consumers.contrib.setup_configuration.steps.ServiceConfigurationStep",
     "notifications_api_common.contrib.setup_configuration.steps.NotificationConfigurationStep",
     "objects.setup_configuration.steps.objecttypes.ObjectTypesConfigurationStep",
+    "mozilla_django_oidc_db.setup_configuration.steps.AdminOIDCConfigurationStep",
 )
+

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -89,4 +89,3 @@ SETUP_CONFIGURATION_STEPS = (
     "objects.setup_configuration.steps.objecttypes.ObjectTypesConfigurationStep",
     "mozilla_django_oidc_db.setup_configuration.steps.AdminOIDCConfigurationStep",
 )
-


### PR DESCRIPTION
Fixes #483 

**Changes**

Includes changes necessary to configure mozilla-django-oidc-db through django-setup-configuration.

~Edit: This branch was based on `feature/467-objecttypes-setup-config` as that includes some changes to the setup configuration structure~

