### PR TITLE
:construction_worker: [#504] Pin to v3.0.1 of publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       docker-image-name: ${{ needs.store-reusable-workflow-vars.outputs.image-name }}
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@5-push-docker-to-latest
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@v3.0.1
     needs:
       - store-reusable-workflow-vars
       - open-api-ci


### PR DESCRIPTION
this version fixes publishing latest docker tag

Fixes #504

