### PR TITLE
Feature/464 permission admin view slow

### DIFF
--- a/src/objects/js/components/admin/permissions/auth-fields.js
+++ b/src/objects/js/components/admin/permissions/auth-fields.js
@@ -61,6 +61,14 @@ const authFields = (object_fields, dataFields, fields, setFields) => {
 };
 
 const versionAuthFields = (objectType, objectFields, dataFieldChoices, fields, setFields) => {
+    if (!(objectType in dataFieldChoices)) {
+        return (
+            <div className="errornote">
+                <p>To be able to select fields, first you must save the instance and then you can edit the fields!</p>
+                <p>Click on button <strong>'Save and continue editing'</strong></p>
+            </div>
+        );
+    }
 
     const dataFields = dataFieldChoices[objectType];
     const objecttypeVersions = Object.entries(dataFieldChoices).reduce((acc, [k, v]) => {

--- a/src/objects/js/components/admin/permissions/permission-form.js
+++ b/src/objects/js/components/admin/permissions/permission-form.js
@@ -9,8 +9,10 @@ const PermissionForm = ({objectFields, dataFieldChoices, tokenChoices, objecttyp
     const [mode, setMode]  = useState(values["mode"]);
     const [useFields, setUseFields] = useState(values["use_fields"]);
     const [objectType, setObjectType] = useState(values["object_type"]);
-
-    const [fields, setFields] = useState( JSON.parse(values["fields"]) || {});
+    if (!values["fields"]) {
+        values["fields"] = "{}"
+      }
+    const [fields, setFields] = useState( JSON.parse(values["fields"]) || {})
 
     return (
      <fieldset className="module aligned">
@@ -63,7 +65,7 @@ const PermissionForm = ({objectFields, dataFieldChoices, tokenChoices, objecttyp
                 name="use_fields"
                 id="id_use_fields"
                 label="Use field-based authorization"
-                disabled={mode === "read_and_write" || Object.keys(dataFieldChoices).length === 0}
+                disabled={!mode || mode === "read_and_write"}
                 value={useFields}
                 onChange={(value) => {setUseFields(value)}}
             />

--- a/src/objects/tests/admin/test_token_permissions.py
+++ b/src/objects/tests/admin/test_token_permissions.py
@@ -6,7 +6,12 @@ from maykin_2fa.test import disable_admin_mfa
 from requests.exceptions import ConnectionError
 
 from objects.accounts.tests.factories import UserFactory
-from objects.token.tests.factories import ObjectTypeFactory, TokenAuthFactory
+from objects.token.constants import PermissionModes
+from objects.token.tests.factories import (
+    ObjectTypeFactory,
+    PermissionFactory,
+    TokenAuthFactory,
+)
 
 from ..utils import mock_objecttype, mock_objecttype_version, mock_service_oas_get
 
@@ -37,18 +42,7 @@ class AddPermissionTests(WebTest):
         response = self.app.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.context["data_field_choices"],
-            {
-                object_type.id: {
-                    1: {},
-                    2: {
-                        "diameter": "record__data__diameter",
-                        "plantDate": "record__data__plantDate",
-                    },
-                }
-            },
-        )
+        self.assertEqual(response.context["data_field_choices"], {})
 
     def test_get_permission_with_unavailable_objecttypes(self, m):
         """
@@ -63,3 +57,77 @@ class AddPermissionTests(WebTest):
         response = self.app.get(self.url)
 
         self.assertEqual(response.status_code, 200)
+
+
+@disable_admin_mfa()
+@requests_mock.Mocker()
+class ChangePermissionTests(WebTest):
+
+    def setUp(self):
+        user = UserFactory(is_superuser=True, is_staff=True)
+        self.app.set_user(user)
+
+        self.object_type = ObjectTypeFactory.create(service__api_root=OBJECT_TYPES_API)
+        self.token_auth = TokenAuthFactory.create()
+
+    def test_change_permission_data_field_choices_disabled(self, m):
+        url = reverse_lazy("admin:token_permission_change")
+        # use_fields disabled
+        permission = PermissionFactory.create(
+            object_type=self.object_type,
+            mode=PermissionModes.read_only,
+            token_auth=self.token_auth,
+        )
+
+        url = reverse_lazy("admin:token_permission_change", args=(permission.id,))
+
+        # mock objecttypes api
+        mock_service_oas_get(m, OBJECT_TYPES_API, "objecttypes")
+        m.get(f"{OBJECT_TYPES_API}objecttypes", json=[])
+        m.get(self.object_type.url, json=mock_objecttype(self.object_type.url))
+        version1 = mock_objecttype_version(
+            self.object_type.url, attrs={"jsonSchema": {}}
+        )
+        version2 = mock_objecttype_version(self.object_type.url, attrs={"version": 2})
+        m.get(f"{self.object_type.url}/versions", json=[version1, version2])
+
+        response = self.app.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["data_field_choices"], {})
+
+    def test_change_permission_data_field_choices_enabled(self, m):
+        url = reverse_lazy("admin:token_permission_change")
+        # use_fields enabled
+        permission = PermissionFactory.create(
+            object_type=self.object_type,
+            mode=PermissionModes.read_only,
+            token_auth=self.token_auth,
+            use_fields=True,
+        )
+
+        url = reverse_lazy("admin:token_permission_change", args=(permission.id,))
+
+        # mock objecttypes api
+        mock_service_oas_get(m, OBJECT_TYPES_API, "objecttypes")
+        m.get(f"{OBJECT_TYPES_API}objecttypes", json=[])
+        m.get(self.object_type.url, json=mock_objecttype(self.object_type.url))
+        version1 = mock_objecttype_version(
+            self.object_type.url, attrs={"jsonSchema": {}}
+        )
+        version2 = mock_objecttype_version(self.object_type.url, attrs={"version": 2})
+        m.get(f"{self.object_type.url}/versions", json=[version1, version2])
+
+        response = self.app.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["data_field_choices"],
+            {
+                self.object_type.id: {
+                    1: {},
+                    2: {
+                        "diameter": "record__data__diameter",
+                        "plantDate": "record__data__plantDate",
+                    },
+                }
+            },
+        )


### PR DESCRIPTION
Fixes #464 

**Changes**

From ticket comments to solve the slow page loading, the option was chosen not to load all the fields of each `objecttype ` unnecessarily, because only one `objecttype` is to be used at a time, so it was decided to only load them when the `objecttype` is selected and the `use_fields` flag is also enabled.

The initial option I had thought of was to do this on the FE side so that I could make single requests for each `objecttype`, but this is more difficult because I would have to pass to the view context more elements such as `uuid`, `service data`, `token` eg. of the `object_type` to then form, for a correctly and secure request;
So I decided to add a simple control that in order to modify the fields of the `permission` must exist and the `use_fields` must also be enabled. 
This way, when the page is reloaded, the permission has all the data and can directly retrieve the information about the fields choices.


![image](https://github.com/user-attachments/assets/4d227039-2a72-4557-8fee-5cb36a81c507)
