### PR TITLE
:arrow_up: bump django to 4.2.19, cryptography to 44.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,14 +63,14 @@ coreapi==2.3.3
     # via commonground-api-common
 coreschema==0.0.4
     # via coreapi
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   django-simple-certmanager
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
     #   webauthn
-django==4.2.17
+django==4.2.19
     # via
     #   commonground-api-common
     #   django-admin-index

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -136,7 +136,7 @@ coverage==4.5.4
     # via
     #   -r requirements/test-tools.in
     #   codecov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -147,7 +147,7 @@ cryptography==44.0.0
     #   webauthn
 cssselect==1.1.0
     # via pyquery
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -166,7 +166,7 @@ coverage==4.5.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   codecov
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -180,7 +180,7 @@ cssselect==1.1.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   pyquery
-django==4.2.17
+django==4.2.19
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Fixes #

**Changes**

[Describe the changes here]

