### PR TITLE
⚡ [#538] Optimize objects list performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,28 @@ jobs:
       - name: Publish coverage report
         uses: codecov/codecov-action@v4
 
+  performance-tests:
+    name: Run the performance test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bring up docker compose and load data
+        run: |
+          docker compose up -d --build || ( docker compose logs >&2 && exit 1; )
+          until docker compose logs web | grep -q "spawned uWSGI worker"; do
+            echo "uWSGI not running yet, waiting..."
+            sleep 3
+          done
+          docker compose exec --user root web pip install factory-boy
+          cat performance_test/create_data.py | docker compose exec -T web src/manage.py shell
+
+      - name: Run tests
+        run: |
+          pip install -r requirements/ci.txt
+          pytest performance_test/ --benchmark-json output.json
+
   docs:
     runs-on: ubuntu-latest
     name: Documentation build

--- a/performance_test/conftest.py
+++ b/performance_test/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+def benchmark_assertions(benchmark):
+    def wrapper(**kwargs):
+        stats = benchmark.stats["stats"]
+        for name, value in kwargs.items():
+            assert (
+                getattr(stats, name) < value
+            ), f"{name} {getattr(stats, name)}s exceeded {value}s"
+
+    return wrapper

--- a/performance_test/create_data.py
+++ b/performance_test/create_data.py
@@ -1,0 +1,17 @@
+from objects.core.tests.factories import ObjectRecordFactory, ObjectTypeFactory
+from objects.token.tests.factories import TokenAuthFactory
+
+object_type = ObjectTypeFactory.create(
+    service__api_root="http://localhost:8001/api/v2/",
+    uuid="f1220670-8ab7-44f1-a318-bd0782e97662",
+)
+
+token = TokenAuthFactory(token="secret", is_superuser=True)
+
+ObjectRecordFactory.create_batch(
+    5000,
+    object__object_type=object_type,
+    start_at="2020-01-01",
+    version=1,
+    data={"kiemjaar": "1234"},
+)

--- a/performance_test/test_objects_list.py
+++ b/performance_test/test_objects_list.py
@@ -1,0 +1,29 @@
+import pytest
+import requests
+from furl import furl
+
+BASE_URL = furl("http://localhost:8000/api/v2/")
+AUTH_HEADERS = {"Authorization": "Token secret"}
+
+
+@pytest.mark.benchmark(max_time=60, min_rounds=5)
+def test_objects_api_list(benchmark, benchmark_assertions):
+    """
+    Regression test for maykinmedia/objects-api#538
+    """
+    params = {
+        "pageSize": 1000,
+        "type": "http://localhost:8001/api/v2/objecttypes/f1220670-8ab7-44f1-a318-bd0782e97662",
+        "data_attrs": "kiemjaar__exact__1234",
+        "ordering": "-record__data__contactmoment__datumContact",
+    }
+
+    def make_request():
+        return requests.get((BASE_URL / "objects").set(params), headers=AUTH_HEADERS)
+
+    result = benchmark(make_request)
+
+    assert result.status_code == 200
+    assert result.json()["count"] == 5000
+
+    benchmark_assertions(mean=1, max=1)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -534,6 +534,8 @@ psycopg2==2.9.9
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
+py-cpuinfo==9.0.0
+    # via pytest-benchmark
 pycodestyle==2.12.1
     # via flake8
 pycparser==2.20
@@ -584,6 +586,10 @@ pyrsistent==0.17.3
     #   -r requirements/base.txt
     #   jsonschema
 pytest==8.3.3
+    # via
+    #   -r requirements/test-tools.in
+    #   pytest-benchmark
+pytest-benchmark==5.1.0
     # via -r requirements/test-tools.in
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,6 +8,8 @@ bump-my-version
 # Debug tooling
 django-debug-toolbar
 django-extensions
+django-silk
+whitenoise
 
 # Documentation
 sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -42,6 +42,8 @@ attrs==20.3.0
     #   -r requirements/ci.txt
     #   glom
     #   jsonschema
+autopep8==2.3.2
+    # via django-silk
 babel==2.16.0
     # via
     #   -c requirements/ci.txt
@@ -206,6 +208,7 @@ django==4.2.19
     #   django-sendfile2
     #   django-sessionprofile
     #   django-setup-configuration
+    #   django-silk
     #   django-simple-certmanager
     #   django-solo
     #   django-two-factor-auth
@@ -326,6 +329,8 @@ django-setup-configuration==0.7.1
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+django-silk==5.3.2
+    # via -r requirements/dev.in
 django-simple-certmanager==1.4.1
     # via
     #   -c requirements/ci.txt
@@ -448,6 +453,8 @@ glom==23.5.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   mozilla-django-oidc-db
+gprof2dot==2024.6.6
+    # via django-silk
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7
@@ -637,6 +644,7 @@ pycodestyle==2.12.1
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   autopep8
     #   flake8
 pycparser==2.20
     # via
@@ -881,6 +889,7 @@ sqlparse==0.5.0
     #   -r requirements/ci.txt
     #   django
     #   django-debug-toolbar
+    #   django-silk
 tblib==1.7.0
     # via
     #   -c requirements/ci.txt
@@ -975,6 +984,8 @@ webtest==2.0.35
     #   django-webtest
 wheel==0.42.0
     # via pip-tools
+whitenoise==6.9.0
+    # via -r requirements/dev.in
 wrapt==1.14.1
     # via
     #   -c requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -640,6 +640,11 @@ psycopg2==2.9.9
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+py-cpuinfo==9.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-benchmark
 pycodestyle==2.12.1
     # via
     #   -c requirements/ci.txt
@@ -708,6 +713,11 @@ pyrsistent==0.17.3
     #   -r requirements/ci.txt
     #   jsonschema
 pytest==8.3.3
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   pytest-benchmark
+pytest-benchmark==5.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -4,6 +4,7 @@
 # Dependencies only relevant for (unit) testing
 codecov
 pytest
+pytest-benchmark
 coverage < 5.0
 django-webtest
 factory-boy

--- a/src/objects/conf/dev.py
+++ b/src/objects/conf/dev.py
@@ -102,6 +102,15 @@ warnings.filterwarnings(
     r"django\.db\.models\.fields",
 )
 
+#
+# DJANGO-SILK
+#
+if config("PROFILE", default=False, add_to_docs=False):
+    INSTALLED_APPS += ["silk"]
+    MIDDLEWARE = ["silk.middleware.SilkyMiddleware"] + MIDDLEWARE
+    security_index = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
+    MIDDLEWARE.insert(security_index + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
+
 if "test" in sys.argv:
     NOTIFICATIONS_DISABLED = True
 

--- a/src/objects/urls.py
+++ b/src/objects/urls.py
@@ -79,3 +79,7 @@ if settings.DEBUG and apps.is_installed("debug_toolbar"):
     urlpatterns = [
         path("__debug__/", include(debug_toolbar.urls)),
     ] + urlpatterns
+
+
+if apps.is_installed("silk"):
+    urlpatterns += [path(r"silk/", include("silk.urls", namespace="silk"))]


### PR DESCRIPTION
Fixes #538 

Reduces the response time of `GET /api/v2/objects` from about ~8.6s to ~0.26s (for a query that returns 5000 objects)

**Changes**

* Add django-silk for performance profiling
* Optimize objects list performance
* Add basic performance tests with pytest-benchmark

Failing performance test before the changes: https://github.com/maykinmedia/objects-api/actions/runs/13653707936/job/38167868135