### PR TITLE
:arrow_up: Upgrade jinja2 to 3.1.6 to fix security issue

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -222,7 +222,7 @@ isodate==0.6.0
     # via commonground-api-common
 itypes==1.2.0
     # via coreapi
-jinja2==3.1.5
+jinja2==3.1.6
     # via coreschema
 josepy==1.9.0
     # via mozilla-django-oidc

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -435,7 +435,7 @@ itypes==1.2.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -508,7 +508,7 @@ itypes==1.2.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   coreapi
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Fixes #543 partially

**Changes**

* Upgrade jinja2 to 3.1.6 to fix security issue
