### PR TITLE
:green_heart: [maykinmedia/open-api-framework#116] Fix codecov publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Publish coverage report
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   performance-tests:
     name: Run the performance test suite


### PR DESCRIPTION
by explicitly using the CODECOV_TOKEN

Fixes maykinmedia/open-api-framework#116 partially

**Changes**

* Fix codecov publish

