### PR TITLE
Updated versions to 3.0.1/3.0.2.

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,11 +10,11 @@ as of March 1, 2022`_. Their specifications can be found below.
 ======================  ==========================================
 API                     Specification version(s)
 ======================  ==========================================
-`Objecttypes API`_      2.2.2 (
+`Objecttypes API`_      3.0.1 (
                         `Redoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/objecttypes-api/3.0.1/src/objecttypes/api/v2/openapi.yaml>`__,
                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/objecttypes-api/3.0.1/src/objecttypes/api/v2/openapi.yaml>`__
                         )
-`Objects API`_          2.4.3 (
+`Objects API`_          3.0.2 (
                         `Redoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/objects-api/3.0.2/src/objects/api/v2/openapi.yaml>`__,
                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/objects-api/3.0.2/src/objects/api/v2/openapi.yaml>`__
                         )


### PR DESCRIPTION
Fixes n/a

**Changes**

Swagger docs refereren naar versie 3.0.1/3.0.2, maar de versie in de link stond nog op 2.x.

