### PR TITLE
:sparkles: Remove django.contrib.sites

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -96,6 +96,7 @@ Optional
 * ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``.
 * ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
 * ``NOTIFICATIONS_DISABLED``: indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to ``True`` for the ``dev`` environment, otherwise defaults to ``False``.
+* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``(empty string)``.
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
 * ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
 * ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -57,7 +57,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-commonground-api-common==2.5.2
+commonground-api-common==2.5.5
     # via open-api-framework
 coreapi==2.3.3
     # via commonground-api-common
@@ -244,11 +244,11 @@ mozilla-django-oidc-db==0.22.0
     # via
     #   -r requirements/base.in
     #   open-api-framework
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -r requirements/base.in
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -115,7 +115,7 @@ click-repl==0.3.0
     #   celery
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.5.2
+commonground-api-common==2.5.5
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -484,12 +484,12 @@ multidict==6.0.5
     # via yarl
 mypy-extensions==1.0.0
     # via black
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -143,7 +143,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.5.2
+commonground-api-common==2.5.5
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -573,12 +573,12 @@ mypy-extensions==1.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   black
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/objects/conf/api.py
+++ b/src/objects/conf/api.py
@@ -109,3 +109,5 @@ SPECTACULAR_SETTINGS = {
 }
 
 UNAUTHORIZED_FIELDS_HEADER = "X-Unauthorized-Fields"
+
+COMMONGROUND_API_COMMON_GET_DOMAIN = "objects.utils.get_domain"

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -11,6 +11,10 @@ DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
 INSTALLED_APPS = INSTALLED_APPS + [
     # Optional applications.
     "django.contrib.gis",
+    # `django.contrib.sites` added at the project level because it has been removed at the packages level.
+    # This component is deprecated and should be completely removed.
+    # To determine the project's domain, use the `SITE_DOMAIN` environment variable.
+    "django.contrib.sites",
     # External applications.
     "rest_framework_gis",
     # Project applications.
@@ -21,7 +25,6 @@ INSTALLED_APPS = INSTALLED_APPS + [
     "objects.token",
     "objects.utils",
 ]
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
@@ -89,3 +92,5 @@ SETUP_CONFIGURATION_STEPS = (
     "objects.setup_configuration.steps.objecttypes.ObjectTypesConfigurationStep",
     "objects.setup_configuration.steps.token_auth.TokenAuthConfigurationStep",
 )
+
+NOTIFICATIONS_API_GET_DOMAIN = "objects.utils.get_domain"

--- a/src/objects/tests/v2/test_notifications_kanaal.py
+++ b/src/objects/tests/v2/test_notifications_kanaal.py
@@ -1,6 +1,5 @@
 from io import StringIO
 
-from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.test import override_settings
 
@@ -17,15 +16,11 @@ from objects.core.models import Object
 NOTIFICATIONS_API_ROOT = "https://notificaties-api.vng.cloud/api/v1/"
 
 
-@override_settings(IS_HTTPS=True)
+@override_settings(IS_HTTPS=True, SITE_DOMAIN="example.com")
 class CreateNotifKanaalTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        site = Site.objects.get_current()
-        site.domain = "example.com"
-        site.save()
-
         kanaal = ObjectKanaal(label="kanaal_test", main_resource=Object)
         cls.addClassCleanup(lambda: KANAAL_REGISTRY.remove(kanaal))
 

--- a/src/objects/utils/__init__.py
+++ b/src/objects/utils/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from django.http import HttpRequest
 
@@ -10,9 +12,14 @@ def get_domain() -> str:
     """
     from django.contrib.sites.models import Site
 
-    if settings.OBJECTS_DOMAIN:
-        return settings.OBJECTS_DOMAIN
+    if settings.SITE_DOMAIN:
+        return settings.SITE_DOMAIN
 
+    warnings.warn(
+        "Deriving the domain from the `Sites` configuration will soon be deprecated, "
+        "please migrate to the SITE_DOMAIN setting.",
+        PendingDeprecationWarning,
+    )
     return Site.objects.get_current().domain
 
 


### PR DESCRIPTION
Partially fixed https://github.com/maykinmedia/open-api-framework/issues/59

- [x] Upgrade open-api-framework==0.9.6
- [x] Upgrade notifications-api-common==0.7.2
- [x] Upgrade commonground-api-common==2.5.5
- [x] Check docs
- [x] Delete django_setup_configuration for site
- [x] Remove from INSTALLED_APPS 
- [x] Remove from Admin
- [x] Revert QRGeneratorView, tests and url