### PR TITLE
fix: added missing type for ObjectRecord - data field in openapi.yaml

### DIFF
--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -1016,6 +1016,8 @@ components:
           minimum: 0
           description: Version of the OBJECTTYPE for data in the object record
         data:
+          type: object
+          additionalProperties: {}
           description: Object data, based on OBJECTTYPE
         geometry:
           allOf:


### PR DESCRIPTION
Added missing type for ObjectRecord - data field in openapi.yaml so that client code can successfully be generated from this OpenAPI specification

Fixes #576

**Changes**

- Added missing type for ObjectRecord - data field in openapi.yaml so that client code can successfully be generated from this OpenAPI specification

