### PR TITLE
Issue/570 remove geo widget

### DIFF
--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -230,10 +230,3 @@ SETUP_CONFIGURATION_STEPS = (
 )
 
 NOTIFICATIONS_API_GET_DOMAIN = "objects.utils.get_domain"
-
-#
-# Needed for geo widget
-#
-CSP_SCRIPT_SRC = CSP_SCRIPT_SRC + ["cdn.jsdelivr.net"]
-CSP_STYLE_SRC = CSP_STYLE_SRC + ["cdn.jsdelivr.net"]
-CSP_IMG_SRC = CSP_IMG_SRC + ["tile.openstreetmap.org"]

--- a/src/objects/core/admin.py
+++ b/src/objects/core/admin.py
@@ -1,7 +1,8 @@
 import logging
 
 from django.contrib import admin
-from django.contrib.gis.admin.options import GeoModelAdminMixin
+from django.contrib.gis import forms
+from django.contrib.gis.db.models import GeometryField
 from django.http import JsonResponse
 from django.urls import path
 
@@ -46,7 +47,7 @@ class ObjectTypeAdmin(admin.ModelAdmin):
         return JsonResponse(versions, safe=False)
 
 
-class ObjectRecordInline(GeoModelAdminMixin, admin.TabularInline):
+class ObjectRecordInline(admin.TabularInline):
     model = ObjectRecord
     extra = 1
     readonly_fields = ("index", "registration_at", "end_at", "get_corrected_by")
@@ -61,6 +62,8 @@ class ObjectRecordInline(GeoModelAdminMixin, admin.TabularInline):
         "get_corrected_by",
         "correct",
     )
+
+    formfield_overrides = {GeometryField: {"widget": forms.Textarea}}
 
     def has_delete_permission(self, request, obj=None):
         return False

--- a/src/objects/core/admin.py
+++ b/src/objects/core/admin.py
@@ -1,12 +1,13 @@
 import logging
 
+from django import forms
 from django.contrib import admin
-from django.contrib.gis import forms
 from django.contrib.gis.db.models import GeometryField
 from django.http import JsonResponse
 from django.urls import path
 
 import requests
+from vng_api_common.utils import get_help_text
 
 from objects.utils.client import get_objecttypes_client
 
@@ -47,7 +48,19 @@ class ObjectTypeAdmin(admin.ModelAdmin):
         return JsonResponse(versions, safe=False)
 
 
+class ObjectRecordForm(forms.ModelForm):
+
+    class Meta:
+        model: ObjectRecord
+        help_texts = {
+            "geometry": get_help_text("core.ObjectRecord", "geometry")
+            + "\n\n format: SRID=4326;POINT|LINESTRING|POLYGON (LAT LONG, ...)"
+        }
+        fields = "__all__"
+
+
 class ObjectRecordInline(admin.TabularInline):
+    form = ObjectRecordForm
     model = ObjectRecord
     extra = 1
     readonly_fields = ("index", "registration_at", "end_at", "get_corrected_by")

--- a/src/objects/core/utils.py
+++ b/src/objects/core/utils.py
@@ -22,7 +22,7 @@ def check_objecttype_cached(
                 return client.get_objecttype_version(object_type.uuid, version)
             except (requests.RequestException, requests.JSONDecodeError):
                 raise ValidationError(
-                    {"non_field_errors": "Object type version can not be retrieved."},
+                    "Object type version can not be retrieved.",
                     code="invalid",
                 )
 
@@ -31,15 +31,11 @@ def check_objecttype_cached(
         jsonschema.validate(data, vesion_data["jsonSchema"])
     except KeyError:
         raise ValidationError(
-            {
-                "non_field_errors": f"{object_type.versions_url} does not appear to be a valid objecttype."
-            },
+            f"{object_type.versions_url} does not appear to be a valid objecttype.",
             code="invalid_key",
         )
     except jsonschema.exceptions.ValidationError as exc:
-        raise ValidationError(
-            {"non_field_errors": exc.args[0]}, code="invalid_jsonschema"
-        )
+        raise ValidationError(exc.args[0], code="invalid_jsonschema")
 
 
 def can_connect_to_objecttypes() -> bool:


### PR DESCRIPTION
Fixes #570 

**Changes**
- removes geodadminMixin & sets the widget for geometry fields to TextArea
- Fixes issue added in #571 
   - `check_objecttype_cached` from `core/utils` is called in by the admin & the api, the errors  return "non_field_errors" as the key, which DRF uses by default. 
   - The admin however only allows fields of the model or `"__all__"`.
