### PR TITLE
:bug: [#374] Fix: Token auth select is empty when creating a permission

### DIFF
--- a/src/objects/tests/admin/test_token_permissions.py
+++ b/src/objects/tests/admin/test_token_permissions.py
@@ -1,3 +1,5 @@
+import json
+
 from django.urls import reverse_lazy
 
 import requests_mock
@@ -58,3 +60,18 @@ class AddPermissionTests(WebTest):
         response = self.app.get(self.url)
 
         self.assertEqual(response.status_code, 200)
+
+    def test_token_auth_is_preselected_in_select(self, m):
+        token = TokenAuthFactory()
+        url = f"{self.url}?token_auth={token.pk}"
+        page = self.app.get(url)
+
+        form_data_script = page.html.find("script", {"id": "form-data"})
+
+        self.assertIsNotNone(form_data_script)
+
+        form_data = json.loads(form_data_script.string)
+
+        token_auth_value = form_data["values"].get("token_auth")
+
+        self.assertEqual(token_auth_value, str(token.pk))

--- a/src/objects/token/admin.py
+++ b/src/objects/token/admin.py
@@ -36,10 +36,18 @@ class PermissionAdmin(admin.ModelAdmin):
     def get_form_data(self, request, object_id) -> dict:
         obj = self.get_object(request, unquote(object_id)) if object_id else None
         ModelForm = self.get_form(request, obj, change=not obj)
+
+        initial = {}
+        token_auth_id = request.GET.get("token_auth") or request.GET.get(
+            "initial-token_auth"
+        )
+        if token_auth_id and not obj:
+            initial["token_auth"] = token_auth_id
+
         if request.method == "POST":
             form = ModelForm(request.POST, request.FILES, instance=obj)
         else:
-            form = ModelForm(instance=obj)
+            form = ModelForm(instance=obj, initial=initial)
         form.is_valid()
 
         values = {field.name: field.value() for field in form}


### PR DESCRIPTION
Fixes #374

