### PR TITLE
🐛 [#576] fix invalid data field type in api spec

### DIFF
--- a/src/objects/api/v2/openapi.yaml
+++ b/src/objects/api/v2/openapi.yaml
@@ -858,6 +858,8 @@ components:
           minimum: 0
           description: Version of the OBJECTTYPE for data in the object record
         data:
+          type: object
+          additionalProperties: true
           description: Object data, based on OBJECTTYPE
         geometry:
           allOf:
@@ -1016,6 +1018,8 @@ components:
           minimum: 0
           description: Version of the OBJECTTYPE for data in the object record
         data:
+          type: object
+          additionalProperties: true
           description: Object data, based on OBJECTTYPE
         geometry:
           allOf:
@@ -1178,6 +1182,8 @@ components:
           type: boolean
           description: Use field-based authorization
         fields:
+          type: object
+          additionalProperties: true
           nullable: true
           title: Mode
           description: Fields allowed for this token in relation to objecttype versions.

--- a/src/objects/utils/apps.py
+++ b/src/objects/utils/apps.py
@@ -1,6 +1,10 @@
 from django.apps import AppConfig
+from django.db import models
 
 from drf_spectacular.extensions import OpenApiFilterExtension
+from rest_framework.serializers import ModelSerializer
+
+from .fields import JSONObjectField
 
 
 def unregister_camelize_filter_extension():
@@ -23,3 +27,6 @@ class UtilsConfig(AppConfig):
         from . import oas_extensions  # noqa
 
         unregister_camelize_filter_extension()
+
+        field_mapping = ModelSerializer.serializer_field_mapping
+        field_mapping[models.JSONField] = JSONObjectField

--- a/src/objects/utils/fields.py
+++ b/src/objects/utils/fields.py
@@ -1,0 +1,9 @@
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+
+@extend_schema_field({"type": "object", "additionalProperties": True})
+class JSONObjectField(serializers.JSONField):
+    """
+    serializers.JSONField does not have a type by default and will show `any` in api spec.
+    """


### PR DESCRIPTION
Fixes #576 

**Changes**
- Overrides the serializer_field_mapping for models.JSONField

- inspired/copied from [rest-framework-gis](https://github.com/openwisp/django-rest-framework-gis/blob/master/rest_framework_gis/apps.py)
- rest-framework-gis is also the reason that setting the mapping in a mixin is not possible:
```py
class JsonObjectFieldModelSerializerMixin:
    serializer_field_mapping = (
        serializers.ModelSerializer.serializer_field_mapping.copy()
    )
    serializer_field_mapping[models.JSONField] = JSONObjectField
``` 
