### PR TITLE
:wrench: [maykinmedia/open-api-framework#166] Set CONN_MAX_AGE to 0 if pooling enabled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       CELERY_LOGLEVEL: DEBUG
       DISABLE_2FA: ${DISABLE_2FA:-yes}
       SUBPATH: ${SUBPATH}
-      DB_CONN_MAX_AGE: "0"
       DB_POOL_ENABLED: True
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; exit(requests.head('http://localhost:8000/admin/').status_code not in [200, 302])"]

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -31,7 +31,7 @@ Database
 * ``DB_PASSWORD``: password of the database user. Defaults to: ``objects``.
 * ``DB_HOST``: hostname of the PostgreSQL database. Defaults to ``db`` for the docker environment, otherwise defaults to ``localhost``.
 * ``DB_PORT``: port number of the database. Defaults to: ``5432``.
-* ``DB_CONN_MAX_AGE``: The lifetime of a database connection, as an integer of seconds. Use 0 to close database connections at the end of each request — Django’s historical behavior. This setting must be set to 0 if connection pooling is used. Defaults to: ``60``.
+* ``DB_CONN_MAX_AGE``: The lifetime of a database connection, as an integer of seconds. Use 0 to close database connections at the end of each request — Django’s historical behavior. This setting is ignored if connection pooling is used. Defaults to: ``60``.
 * ``DB_POOL_ENABLED``: Whether to use connection pooling (requires ``DB_CONN_MAX_AGE`` to be set to 0). Defaults to: ``False``.
 * ``DB_POOL_MIN_SIZE``: The minimum number of connection the pool will hold. The pool will actively try to create new connections if some are lost (closed, broken) and will try to never go below min_size. Defaults to: ``4``.
 * ``DB_POOL_MAX_SIZE``: The maximum number of connections the pool will hold. If None, or equal to min_size, the pool will not grow or shrink. If larger than min_size, the pool can grow if more than min_size connections are requested at the same time and will shrink back after the extra connections have been unused for more than max_idle seconds. Defaults to: ``None``.

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -15,7 +15,7 @@ DATABASES["default"]["CONN_MAX_AGE"] = config(
     help_text=(
         "The lifetime of a database connection, as an integer of seconds. "
         "Use 0 to close database connections at the end of each request — Django’s historical behavior. "
-        "This setting must be set to 0 if connection pooling is used. Defaults to: ``60``."
+        "This setting is ignored if connection pooling is used. Defaults to: ``60``."
     ),
     group="Database",
     auto_display_default=False,
@@ -140,6 +140,8 @@ if DB_POOL_ENABLED:
             "num_workers": DB_POOL_NUM_WORKERS,
         }
     }
+    # Cannot use a `CONN_MAX_AGE` other than 0 with connection pooling
+    DATABASES["default"]["CONN_MAX_AGE"] = 0
 
 # Application definition
 


### PR DESCRIPTION
Fixes maykinmedia/open-api-framework#166

**Changes**

* Set CONN_MAX_AGE to 0 if pooling enabled
