### PR TITLE
:wrench: Add envvar to disable server side cursors

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -41,6 +41,7 @@ Database
 * ``DB_POOL_MAX_IDLE``: Maximum time, in seconds, that a connection can stay unused in the pool before being closed, and the pool shrunk. This only happens to connections more than min_size, if max_size allowed the pool to grow. Defaults to: ``600``.
 * ``DB_POOL_RECONNECT_TIMEOUT``: Maximum time, in seconds, the pool will try to create a connection. If a connection attempt fails, the pool will try to reconnect a few times, using an exponential backoff and some random factor to avoid mass attempts. If repeated attempts fail, after reconnect_timeout second the connection attempt is aborted and the reconnect_failed() callback invoked. Defaults to: ``300``.
 * ``DB_POOL_NUM_WORKERS``: Number of background worker threads used to maintain the pool state. Background workers are used for example to create new connections and to clean up connections when they are returned to the pool. Defaults to: ``3``.
+* ``DB_DISABLE_SERVER_SIDE_CURSORS``: Whether or not server side cursors should be disabled for Postgres connections. Setting this to true is required when using a connection pooler in transaction mode (like PgBouncer). **WARNING:** the effect of disabling server side cursors on performance has not been thoroughly tested yet. Defaults to: ``False``.
 
 
 Logging

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -6,6 +6,19 @@ from open_api_framework.conf.utils import config
 
 from .api import *  # noqa
 
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = config(
+    "DB_DISABLE_SERVER_SIDE_CURSORS",
+    False,
+    help_text=(
+        "Whether or not server side cursors should be disabled for Postgres connections. "
+        "Setting this to true is required when using a connection pooler in "
+        "transaction mode (like PgBouncer). "
+        "**WARNING:** the effect of disabling server side cursors on performance has not "
+        "been thoroughly tested yet."
+    ),
+    group="Database",
+)
+
 DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
 
 # Application definition
@@ -316,5 +329,3 @@ NOTIFICATIONS_API_GET_DOMAIN = "objects.utils.get_domain"
 #
 DJANGO_STRUCTLOG_IP_LOGGING_ENABLED = False
 DJANGO_STRUCTLOG_CELERY_ENABLED = True
-
-DISABLE_SERVER_SIDE_CURSORS = True


### PR DESCRIPTION
to make sure Objects API can be used with pgbouncer

Related issue: https://github.com/maykinmedia/open-api-framework/issues/171

**Changes**

* Add envvar to disable server side cursors


