### PR TITLE
:white_check_mark: Use non superuser token and add perftest for objecttype filter

### DIFF
--- a/performance_test/create_data.py
+++ b/performance_test/create_data.py
@@ -6,14 +6,21 @@ from objects.core.tests.factories import (
     ObjectRecordFactory as _ObjectRecordFactory,
     ObjectTypeFactory,
 )
-from objects.token.tests.factories import TokenAuthFactory
+from objects.token.constants import PermissionModes
+from objects.token.tests.factories import PermissionFactory, TokenAuthFactory
 
 object_type = ObjectTypeFactory.create(
     service__api_root="http://localhost:8001/api/v2/",
     uuid="f1220670-8ab7-44f1-a318-bd0782e97662",
 )
 
-token = TokenAuthFactory(token="secret", is_superuser=True)
+token = TokenAuthFactory(token="secret", is_superuser=False)
+PermissionFactory.create(
+    object_type=object_type,
+    mode=PermissionModes.read_only,
+    token_auth=token,
+    use_fields=False,
+)
 
 
 class ObjectRecordFactory(_ObjectRecordFactory):

--- a/performance_test/tests/test_objects_list.py
+++ b/performance_test/tests/test_objects_list.py
@@ -98,3 +98,25 @@ def test_objects_api_list_filter_one_result(benchmark, benchmark_assertions):
     assert result.json()["count"] == 1
 
     benchmark_assertions(mean=1, max=1)
+
+
+@pytest.mark.benchmark(max_time=60, min_rounds=5)
+def test_objects_api_list_filter_by_object_type(benchmark, benchmark_assertions):
+    """
+    Regression test for maykinmedia/objects-api#677
+    """
+    params = {
+        "pageSize": 100,
+        "type": "http://localhost:8001/api/v2/objecttypes/f1220670-8ab7-44f1-a318-bd0782e97662",
+        "ordering": "-record__data__nested__timestamp",
+    }
+
+    def make_request():
+        return requests.get((BASE_URL / "objects").set(params), headers=AUTH_HEADERS)
+
+    result = benchmark(make_request)
+
+    assert result.status_code == 200
+    assert result.json()["count"] == 5001
+
+    benchmark_assertions(mean=1, max=1)


### PR DESCRIPTION
I slightly modified the performance tests in https://github.com/maykinmedia/objects-api/pull/678, making them use non superuser tokens, which increases the response times in the performance tests. I'm putting it in a separate PR to show that https://github.com/maykinmedia/objects-api/pull/678 does actually improve performance, compared to main