### PR TITLE
add correct resource to notification docs

### DIFF
--- a/src/notificaties.md
+++ b/src/notificaties.md
@@ -27,6 +27,6 @@ De architectuur van de notificaties staat beschreven op <a href="https://github.
 **Resources en acties**
 
 
-* <code>objectrecord</code>: create, update, destroy, create, update, destroy
+* <code>object</code>: create, update, destroy
 
 


### PR DESCRIPTION
Fixes #689 

**Changes**

- set notif resource to object.

the resource was set to `objectrecord` because its fetched from the viewset queryset within NotificationMixinBase.

This pr just sets it to object hardcoded. Another solution would be to completely override the mxinxbase so that  resource can become:

```python
resource = (  
            new_cls.notification_resource._meta.model_name  
            or new_cls.queryset.model._meta.model_name  
        )  
```

so that `notification_resource` can be defined on the viewset but it seemed a bit overkill.

