### PR TITLE
:memo: Add 3.6.1 changelog and update 4.0 migration docs to mention 3.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Major release
 
     This version combines the Objects API and Objecttypes into a single application named
     Open Object. This application no longer supports objecttypes hosted in an external application.
-    Before upgrading to 4.0.0, it is required to first update to Objects API version 3.6.0 and run an import command
+    Before upgrading to 4.0.0, it is required to first update to Objects API version 3.6.1 and run an import command
     to locally import the objecttypes (make sure to read :ref:`objecttype_migration` for more details).
 
 .. warning::
@@ -102,6 +102,13 @@ Major release
 **Documentation**
 
 * [:open-api-framework:`205`] Describe version policy + supported versions in documentation (see :ref:`versioning_policy`)
+
+3.6.1 (2026-05-22)
+------------------
+
+**Bugfixes**
+
+* [:open-object:`756`] Preserve camelcasing for jsonschema in ``import_objecttypes`` command
 
 3.6.0 (2026-02-06)
 ------------------

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -40,7 +40,10 @@ latest                  n/a             `ReDoc <https://redocly.github.io/redoc/
                                         (`verschillen <https://github.com/maykinmedia/open-object/compare/4.0.0..4.0.1>`_)
 4.0.0                   2026-04-13      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/4.0.0/src/objects/api/v2/openapi.yaml>`_,
                                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/4.0.0/src/objects/api/v2/openapi.yaml>`_
-                                        (`verschillen <https://github.com/maykinmedia/open-object/compare/3.6.0..4.0.0>`_)
+                                        (`verschillen <https://github.com/maykinmedia/open-object/compare/3.6.1..4.0.0>`_)
+3.6.1                   2026-05-22      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.1/src/objects/api/v2/openapi.yaml>`_,
+                                        `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.1/src/objects/api/v2/openapi.yaml>`_
+                                        (`verschillen <https://github.com/maykinmedia/open-object/compare/3.6.0..3.6.1>`_)
 3.6.0                   2026-02-06      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.0/src/objects/api/v2/openapi.yaml>`_,
                                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.0/src/objects/api/v2/openapi.yaml>`_
                                         (`verschillen <https://github.com/maykinmedia/open-object/compare/3.5.0..3.6.0>`_)

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,10 @@ latest                  n/a             `ReDoc <https://redocly.github.io/redoc/
                                         (`diff <https://github.com/maykinmedia/open-object/compare/4.0.0..4.0.1>`_)
 4.0.0                   2026-04-13      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/4.0.0/src/objects/api/v2/openapi.yaml>`_,
                                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/4.0.0/src/objects/api/v2/openapi.yaml>`_
-                                        (`diff <https://github.com/maykinmedia/open-object/compare/3.6.0..4.0.0>`_)
+                                        (`diff <https://github.com/maykinmedia/open-object/compare/3.6.1..4.0.0>`_)
+3.6.1                   2026-05-22      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.1/src/objects/api/v2/openapi.yaml>`_,
+                                        `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.1/src/objects/api/v2/openapi.yaml>`_
+                                        (`diff <https://github.com/maykinmedia/open-object/compare/3.6.0..3.6.1>`_)
 3.6.0                   2026-02-06      `ReDoc <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.0/src/objects/api/v2/openapi.yaml>`_,
                                         `Swagger <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/maykinmedia/open-object/3.6.0/src/objects/api/v2/openapi.yaml>`_
                                         (`diff <https://github.com/maykinmedia/open-object/compare/3.5.0..3.6.0>`_)

--- a/docs/installation/observability/logging.rst
+++ b/docs/installation/observability/logging.rst
@@ -171,7 +171,7 @@ Data migrations
 Migration checks
 ----------------
 
-* ``unimported_objecttypes``: when upgrading from Objects API 3.6.0 to Open Object 4.0.0,
+* ``unimported_objecttypes``: when upgrading from Objects API 3.6.1 to Open Object 4.0.0,
   objecttypes where found that have not been imported with the ``import_objecttypes`` command (see :ref:`objecttype_migration`).
   Additional context: ``uuids``.
 

--- a/docs/manual/migration.rst
+++ b/docs/manual/migration.rst
@@ -9,10 +9,10 @@ This means that from version 4.0.0 onwards only objecttypes that exist in the da
 Version flow
 ------------
 
-Objects API versions below 3.6.0 first need be upgraded to 3.6.0 and then need to run the ``import_objecttypes`` command. After this is done, the instance can be safely upgraded to 4.0.0.
-If there are remaining external objecttypes the container will fail during startup (and block any database schema changes introduced in 4.0.0) and you will need to roll back to 3.6.0.
+Objects API versions below 3.6.1 first need be upgraded to 3.6.1 and then need to run the ``import_objecttypes`` command. After this is done, the instance can be safely upgraded to 4.0.0.
+If there are remaining external objecttypes the container will fail during startup (and block any database schema changes introduced in 4.0.0) and you will need to roll back to 3.6.1.
 
-If it is on ``latest`` it should ideally go to 3.6.0 before upgrading to 4.0.0. If the latest tag is pulled and the container is updated,
+If it is on ``latest`` it should ideally go to 3.6.1 before upgrading to 4.0.0. If the latest tag is pulled and the container is updated,
 it will not fail for remaining external objecttypes. This can be fixed by running ``import_objecttypes`` in 4.0.0 for each objecttype service.
 
 Importing objecttype data

--- a/src/objects/conf/base.py
+++ b/src/objects/conf/base.py
@@ -190,7 +190,7 @@ LOGIN_URLS = [reverse_lazy("admin:login")]
 
 UPGRADE_CHECK_PATHS: UpgradePaths = {
     "4.0.0": UpgradeCheck(
-        VersionRange(minimum="3.6.0"),
+        VersionRange(minimum="3.6.1"),
         code_checks=[CommandCheck("check_for_external_objecttypes")],
     ),
 }

--- a/src/objects/core/tests/test_upgrade_check.py
+++ b/src/objects/core/tests/test_upgrade_check.py
@@ -36,7 +36,7 @@ class TestUpgradeCheckBefore40(BaseMigrationTest):
     @override_settings(RELEASE="4.0.0")
     def test_upgrade_from_30_to_40(self):
         """
-        from 3.0.0 directly to 4.0.0 is not allowed, 3.6.0 is the minimum version
+        from 3.0.0 directly to 4.0.0 is not allowed, 3.6.1 is the minimum version
 
         """
         Version.objects.create(version="3.0.0", git_sha="test")
@@ -49,7 +49,7 @@ class TestUpgradeCheckBefore40(BaseMigrationTest):
         """
         import should fail because non-imported objecttypes exist
         """
-        Version.objects.create(version="3.6.0", git_sha="test")
+        Version.objects.create(version="3.6.1", git_sha="test")
         self.ObjectType.objects.create(
             is_imported=False, uuid=uuid.uuid4(), service=self.service
         )
@@ -62,7 +62,7 @@ class TestUpgradeCheckBefore40(BaseMigrationTest):
         """
         import should succeed because all objecttypes are imported
         """
-        Version.objects.create(version="3.6.0", git_sha="test")
+        Version.objects.create(version="3.6.1", git_sha="test")
         self.ObjectType.objects.create(
             is_imported=True, uuid=uuid.uuid4(), service=self.service
         )
@@ -98,7 +98,7 @@ class TestUpgradeCheckBefore40(BaseMigrationTest):
 class TestUpgradeCheckAfter40(TestCase):
     @override_settings(RELEASE="4.0.0")
     def test_upgrade_from_36_to_40_with_non_imported(self):
-        Version.objects.create(version="3.6.0", git_sha="test")
+        Version.objects.create(version="3.6.1", git_sha="test")
         ObjectTypeFactory.create(is_imported=False)
 
         with self.assertRaises(SystemCheckError):
@@ -106,7 +106,7 @@ class TestUpgradeCheckAfter40(TestCase):
 
     @override_settings(RELEASE="4.0.0")
     def test_upgrade_from_36_to_40_with_imported(self):
-        Version.objects.create(version="3.6.0", git_sha="test")
+        Version.objects.create(version="3.6.1", git_sha="test")
         ObjectTypeFactory.create(is_imported=True)
 
         call_command("check")


### PR DESCRIPTION
because in 3.6.0 the objecttype migration command has a bug where jsonschema keys are mutated

Related to #756 
