### PR TITLE
Fix PATCH/PUT with UUID field throws error in 40x

### DIFF
--- a/src/objects/api/serializers.py
+++ b/src/objects/api/serializers.py
@@ -27,6 +27,7 @@ from .validators import (
     IsImmutableValidator,
     JsonSchemaValidator,
     ObjectTypeSchemaValidator,
+    ObjectUUIDUniqueValidator,
     VersionUpdateValidator,
 )
 
@@ -244,10 +245,7 @@ class ObjectSerializer(DynamicFieldsMixin, serializers.HyperlinkedModelSerialize
         required=False,
         validators=[
             IsImmutableValidator(),
-            UniqueValidator(
-                queryset=Object.objects.all(),
-                message=_("An object with this UUID already exists."),
-            ),
+            ObjectUUIDUniqueValidator(),
         ],
         help_text=_("Unique identifier (UUID4)"),
     )

--- a/src/objects/api/validators.py
+++ b/src/objects/api/validators.py
@@ -4,11 +4,36 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.fields import get_attribute
 
+from objects.core.models import Object
 from objects.core.utils import check_json_schema, check_objecttype
 
 from ..core.constants import ObjectTypeVersionStatus
 from .constants import Operators
 from .utils import merge_patch, string_to_value
+
+
+class ObjectUUIDUniqueValidator:
+    """
+    Validate that the UUID is unique, but only on create.
+
+    On update, the IsImmutableValidator ensures the UUID doesn't change,
+    so we don't need to check uniqueness (and the standard UniqueValidator
+    can't properly exclude the current instance because the serializer's
+    instance is an ObjectRecord, not an Object).
+    """
+
+    message = _("An object with this UUID already exists.")
+    code = "unique"
+    requires_context = True
+
+    def __call__(self, value, serializer_field):
+        instance = getattr(serializer_field.parent, "instance", None)
+        # no instance -> it's a create, check uniqueness
+        if instance is not None:
+            return
+
+        if Object.objects.filter(uuid=value).exists():
+            raise serializers.ValidationError(self.message, code=self.code)
 
 
 class VersionUpdateValidator:

--- a/src/objects/tests/v2/test_object_api.py
+++ b/src/objects/tests/v2/test_object_api.py
@@ -314,6 +314,65 @@ class ObjectApiTests(TokenAuthMixin, APITestCase):
         self.assertEqual(initial_record.corrected, current_record)
         self.assertEqual(initial_record.end_at, date(2020, 1, 1))
 
+    def test_patch_object_with_uuid_in_body(self):
+        """Regression test for PATCH/PUT with uuid field in body.
+
+        In 3.6.0, including the uuid in the request body during PATCH/PUT
+        worked correctly. In 4.0.0, it returned a 400 error:
+        "An object with this UUID already exists."
+        """
+        # Explicitly set different IDs so Object.pk != ObjectRecord.pk.
+        # The default UniqueValidator excludes by pk=instance.pk (ObjectRecord.pk) from
+        # Object.objects, which fails when the PKs don't match.
+        initial_record = ObjectRecordFactory.create(
+            id=100,
+            object__id=1,
+            object__object_type=self.object_type,
+            version=1,
+            start_at=date.today(),
+            data={"name": "Name", "diameter": 20},
+        )
+        obj = initial_record.object
+
+        url = reverse("object-detail", args=[obj.uuid])
+        data = {
+            "uuid": str(obj.uuid),
+            "record": {
+                "data": {"diameter": 30},
+            },
+        }
+
+        response = self.client.patch(url, data, **GEO_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_put_object_with_uuid_in_body(self):
+        """PUT with uuid field in body should work (same UUID as existing object)."""
+        initial_record = ObjectRecordFactory.create(
+            id=100,
+            object__id=1,
+            object__object_type=self.object_type,
+            version=1,
+            start_at=date.today(),
+            data={"name": "Name", "diameter": 20},
+        )
+        obj = initial_record.object
+
+        url = reverse("object-detail", args=[obj.uuid])
+        data = {
+            "uuid": str(obj.uuid),
+            "type": f"http://testserver{reverse('objecttype-detail', args=[self.object_type.uuid])}",
+            "record": {
+                "typeVersion": 1,
+                "data": {"name": "Name", "diameter": 30},
+                "startAt": "2020-01-01",
+            },
+        }
+
+        response = self.client.put(url, data, **GEO_WRITE_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
     def test_patch_validates_merged_object_rather_than_partial_object(self):
         initial_record = ObjectRecordFactory.create(
             version=1,


### PR DESCRIPTION

Fixes #765

- **:test_tube: test: add regression test PUT/PATCH record with UUID set**
- **:bug: fix: POST/PATCH object with UUID set**
